### PR TITLE
Merge binary mode and ascii mode into one node

### DIFF
--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
@@ -67,6 +67,7 @@ private:
   DataFormat data_format_;
   bool imu_data_has_refreshed_;
 
+  bool isValidAsciiSensorData(std::vector<std::string> imu_data_vector_buf);
   bool readBinaryData(void);
   bool readAsciiData(void);
 

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
@@ -54,6 +54,18 @@ private:
   double magnetic_field_stddev_;
   rt_usb_9axisimu::Consts consts;
 
+  enum DataFormat
+  {
+    NONE = 0,
+    NOT_BINARY,
+    BINARY,
+    NOT_ASCII,
+    ASCII,
+    INCORRECT
+  };
+  bool format_check_has_completed_;
+  DataFormat data_format_;
+
 public:
   RtUsb9axisimuBinaryModeRosDriver(std::string serialport);
   ~RtUsb9axisimuBinaryModeRosDriver();
@@ -65,6 +77,13 @@ public:
   bool isBinarySensorData(unsigned char* imu_data_buf);
 
   bool startCommunication();
+  void stopCommunication(void);
+  void checkDataFormat(void);
+  bool formatCheckHasCompleted(void);
+  bool hasCorrectDataFormat(void);
+  bool hasAsciiDataFormat(void);
+  bool hasBinaryDataFormat(void);
+
   // Method to combine two separate one-byte data into one two-byte data
   signed short combineByteData(unsigned char data_h, unsigned char data_l);
   // Method to extract binary sensor data from communication buffer

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
@@ -65,6 +65,7 @@ private:
   };
   bool format_check_has_completed_;
   DataFormat data_format_;
+  bool imu_data_has_refreshed_;
 
   bool readBinaryData(void);
   bool readAsciiData(void);
@@ -86,6 +87,7 @@ public:
   bool hasCorrectDataFormat(void);
   bool hasAsciiDataFormat(void);
   bool hasBinaryDataFormat(void);
+  bool imuDataHasRefreshed(void);
 
   // Method to combine two separate one-byte data into one two-byte data
   signed short combineByteData(unsigned char data_h, unsigned char data_l);

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
@@ -66,6 +66,9 @@ private:
   bool format_check_has_completed_;
   DataFormat data_format_;
 
+  bool readBinaryData(void);
+  bool readAsciiData(void);
+
 public:
   RtUsb9axisimuBinaryModeRosDriver(std::string serialport);
   ~RtUsb9axisimuBinaryModeRosDriver();

--- a/src/rt_usb_9axisimu_binary_mode.cpp
+++ b/src/rt_usb_9axisimu_binary_mode.cpp
@@ -45,6 +45,9 @@ RtUsb9axisimuBinaryModeRosDriver::RtUsb9axisimuBinaryModeRosDriver(std::string p
   imu_data_raw_pub_ = nh_.advertise<sensor_msgs::Imu>("imu/data_raw", 1);
   imu_mag_pub_ = nh_.advertise<sensor_msgs::MagneticField>("imu/mag", 1);
   imu_temperature_pub_ = nh_.advertise<std_msgs::Float64>("imu/temperature", 1);
+
+  format_check_has_completed_ = false;
+  data_format_ = DataFormat::NONE;
 }
 
 RtUsb9axisimuBinaryModeRosDriver::~RtUsb9axisimuBinaryModeRosDriver()
@@ -73,6 +76,55 @@ bool RtUsb9axisimuBinaryModeRosDriver::startCommunication()
 {
   // returns serial port open status
   return openSerialPort();
+}
+
+void RtUsb9axisimuBinaryModeRosDriver::stopCommunication(void)
+{
+  closeSerialPort();
+}
+
+void RtUsb9axisimuBinaryModeRosDriver::checkDataFormat(void)
+{
+  if (data_format_ == DataFormat::NONE)
+  {
+    // binary format check
+    // if isBinaryFormat() == True : data_format_ = DataFormat::BINARY
+    // else data_format_ = DataFormat::NOT_BINARY
+  }
+  else if (data_format_ == DataFormat::NOT_BINARY)
+  {
+    // ascii format check
+    // if isAsciiFormat() == True : data_format_ = DataFormat::ASCII
+    // else data_format_ = DataFormat::INCORRECT
+  }
+  data_format_ = DataFormat::BINARY;
+  format_check_has_completed_ = true;
+}
+
+bool RtUsb9axisimuBinaryModeRosDriver::formatCheckHasCompleted(void)
+{
+  return format_check_has_completed_;
+}
+
+bool RtUsb9axisimuBinaryModeRosDriver::hasCorrectDataFormat(void)
+{
+  bool output = true;
+  if (data_format_ == DataFormat::INCORRECT || data_format_ == DataFormat::NOT_ASCII ||
+      data_format_ == DataFormat::NOT_BINARY)
+  {
+    output = false;
+  }
+  return output;
+}
+
+bool RtUsb9axisimuBinaryModeRosDriver::hasAsciiDataFormat(void)
+{
+  return data_format_ == DataFormat::ASCII;
+}
+
+bool RtUsb9axisimuBinaryModeRosDriver::hasBinaryDataFormat(void)
+{
+  return data_format_ == DataFormat::BINARY;
 }
 
 // Method to combine two separate one-byte data into one two-byte data

--- a/src/rt_usb_9axisimu_binary_mode.cpp
+++ b/src/rt_usb_9axisimu_binary_mode.cpp
@@ -87,18 +87,26 @@ void RtUsb9axisimuBinaryModeRosDriver::checkDataFormat(void)
 {
   if (data_format_ == DataFormat::NONE)
   {
-    // binary format check
-    // if isBinaryFormat() == True : data_format_ = DataFormat::BINARY
-    // else data_format_ = DataFormat::NOT_BINARY
+    unsigned char data_buf[256];
+    int data_size_of_buf = readFromDevice(data_buf, consts.IMU_DATA_SIZE);
+    if (data_size_of_buf == consts.IMU_DATA_SIZE)
+    {
+      if (isBinarySensorData(data_buf))
+      {
+        data_format_ = DataFormat::BINARY;
+        format_check_has_completed_ = true;
+      }
+      else
+      {
+        data_format_ = DataFormat::NOT_BINARY;
+      }
+    }
   }
   else if (data_format_ == DataFormat::NOT_BINARY)
   {
-    // ascii format check
-    // if isAsciiFormat() == True : data_format_ = DataFormat::ASCII
-    // else data_format_ = DataFormat::INCORRECT
+    data_format_ = DataFormat::ASCII;
+    format_check_has_completed_ = true;
   }
-  data_format_ = DataFormat::BINARY;
-  format_check_has_completed_ = true;
 }
 
 bool RtUsb9axisimuBinaryModeRosDriver::formatCheckHasCompleted(void)

--- a/src/rt_usb_9axisimu_binary_mode.cpp
+++ b/src/rt_usb_9axisimu_binary_mode.cpp
@@ -119,7 +119,7 @@ bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
     else if (imu_data_vector_buf.size() > 11)
     {
       imu_data_vector_buf.clear();
-      return false;
+      ROS_WARN("ASCII data size is incorrect.");
     }
   }
 

--- a/src/rt_usb_9axisimu_binary_mode.cpp
+++ b/src/rt_usb_9axisimu_binary_mode.cpp
@@ -68,6 +68,19 @@ bool RtUsb9axisimuBinaryModeRosDriver::readBinaryData(void)
   return true;
 }
 
+bool RtUsb9axisimuBinaryModeRosDriver::isValidAsciiSensorData(std::vector<std::string> str_vector)
+{
+  bool ret = true;
+  for (int i = 1; i <= 10; i++)
+  {
+    if (strspn(str_vector[i].c_str(), "-.0123456789") != str_vector[i].size())
+    {
+      ret = false;
+    }
+  }
+  return ret;
+}
+
 bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
 {
   static std::vector<std::string> imu_data_vector_buf;
@@ -99,7 +112,7 @@ bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
     }
 
     if (imu_data_buf[char_count] == '\n' && imu_data_vector_buf.size() == 11 &&
-        imu_data_vector_buf[0].find(".") == std::string::npos)
+        imu_data_vector_buf[0].find(".") == std::string::npos && isValidAsciiSensorData(imu_data_vector_buf))
     {
       imu_data.gx = std::stof(imu_data_vector_buf[1]);
       imu_data.gy = std::stof(imu_data_vector_buf[2]);
@@ -129,7 +142,6 @@ bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
 RtUsb9axisimuBinaryModeRosDriver::RtUsb9axisimuBinaryModeRosDriver(std::string port = "")
   : rt_usb_9axisimu::SerialPort(port.c_str())
 {
-  // nh_priv_("~");
   // publisher for streaming
   imu_data_raw_pub_ = nh_.advertise<sensor_msgs::Imu>("imu/data_raw", 1);
   imu_mag_pub_ = nh_.advertise<sensor_msgs::MagneticField>("imu/mag", 1);

--- a/src/rt_usb_9axisimu_binary_mode.cpp
+++ b/src/rt_usb_9axisimu_binary_mode.cpp
@@ -118,8 +118,8 @@ bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
     }
     else if (imu_data_vector_buf.size() > 11)
     {
-      // TODO ERROR HANDLING
       imu_data_vector_buf.clear();
+      return false;
     }
   }
 

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -58,8 +58,33 @@ int main(int argc, char** argv)
 
   if (sensor.startCommunication())
   {
-    ROS_INFO("RT imu driver initialization OK.\n");
     while (ros::ok())
+    {
+      if (sensor.formatCheckHasCompleted() == false)
+      {
+        sensor.checkDataFormat();
+        continue;
+      }
+      else
+      {
+        ROS_INFO("Format check has completed.");
+        if (sensor.hasCorrectDataFormat() == false)
+        {
+          ROS_ERROR("Data format is neither binary nor ascii.");
+        }
+        else if (sensor.hasAsciiDataFormat())
+        {
+          ROS_INFO("Data format is ascii.");
+        }
+        else if (sensor.hasBinaryDataFormat())
+        {
+          ROS_INFO("Data format is binary.");
+        }
+        break;
+      }
+    }
+
+    while (ros::ok() && sensor.hasCorrectDataFormat())
     {
       if (sensor.readSensorData())
       {
@@ -70,6 +95,8 @@ int main(int argc, char** argv)
         ROS_ERROR("readSensorData() returns false, please check your devices.\n");
       }
     }
+
+    sensor.stopCommunication();
   }
   else
   {

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -88,7 +88,10 @@ int main(int argc, char** argv)
     {
       if (sensor.readSensorData())
       {
-        sensor.publishSensorData();
+        if (sensor.imuDataHasRefreshed())
+        {
+          sensor.publishSensorData();
+        }
       }
       else
       {


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->

rt_usb_9axisimu_ascii_mode.cpp の内容をrt_usb_9axisimu_binary_mode.cppに移植して、ノードを切り替えること無くバイナリモードのデータとアスキーモードのデータを受信します。

バイナリモードのモジュールを接続した状態で`rt_usb_9axisimu_driver`ノードを起動すると、バイナリデータ受信モードでノードが動きます。

アスキーモードのモジュールを接続した状態でノードを起動すると、アスキーデータ受信モードでノードが動きます。

モードの判定は**バイナリモードかどうか**のみをチェックしているので、別のシリアルモジュールの接続は想定していません。（接続した場合は、アスキーモードで動作し、エラーを吐くと思います。）

クラス名変更等の**リファクタリングは別PRで実施**します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
`roslaunch rt_usb_9axisimu_driver rt_usb_9axisimu_driver.launch`を実行し、
アスキーモードのモジュールと、バイナリモードのモジュールのどちらを接続してもIMUトピックが出力されることを確認しました。