### PR TITLE
Fix an error when receiving unexpected string

### DIFF
--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_binary_mode.hpp
@@ -67,6 +67,7 @@ private:
   DataFormat data_format_;
   bool imu_data_has_refreshed_;
 
+  bool isValidAsciiSensorData(std::vector<std::string> imu_data_vector_buf);
   bool readBinaryData(void);
   bool readAsciiData(void);
 

--- a/src/rt_usb_9axisimu_binary_mode.cpp
+++ b/src/rt_usb_9axisimu_binary_mode.cpp
@@ -68,6 +68,19 @@ bool RtUsb9axisimuBinaryModeRosDriver::readBinaryData(void)
   return true;
 }
 
+bool RtUsb9axisimuBinaryModeRosDriver::isValidAsciiSensorData(std::vector<std::string> str_vector)
+{
+  bool ret = true;
+  for (int i = 1; i <= 10; i++)
+  {
+    if (strspn(str_vector[i].c_str(), "-.0123456789") != str_vector[i].size())
+    {
+      ret = false;
+    }
+  }
+  return ret;
+}
+
 bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
 {
   static std::vector<std::string> imu_data_vector_buf;
@@ -99,7 +112,7 @@ bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
     }
 
     if (imu_data_buf[char_count] == '\n' && imu_data_vector_buf.size() == 11 &&
-        imu_data_vector_buf[0].find(".") == std::string::npos)
+        imu_data_vector_buf[0].find(".") == std::string::npos && isValidAsciiSensorData(imu_data_vector_buf))
     {
       imu_data.gx = std::stof(imu_data_vector_buf[1]);
       imu_data.gy = std::stof(imu_data_vector_buf[2]);
@@ -129,7 +142,6 @@ bool RtUsb9axisimuBinaryModeRosDriver::readAsciiData(void)
 RtUsb9axisimuBinaryModeRosDriver::RtUsb9axisimuBinaryModeRosDriver(std::string port = "")
   : rt_usb_9axisimu::SerialPort(port.c_str())
 {
-  // nh_priv_("~");
   // publisher for streaming
   imu_data_raw_pub_ = nh_.advertise<sensor_msgs::Imu>("imu/data_raw", 1);
   imu_mag_pub_ = nh_.advertise<sensor_msgs::MagneticField>("imu/mag", 1);


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->
9軸IMUASCII版以外の文字列を受け取ったときにエラーが出てプロセスが停止する問題を修正します。

```
[ INFO] [1592993554.204090319]: Data format is ascii.
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stof
```

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。
このコメント分の修正です。
https://github.com/rt-net/rt_usb_9axisimu_driver/pull/19#pullrequestreview-436514795

関連 #18

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
hogehoge
foobar
など9軸IMUが出力しない文字列をttyデバイス経由で受信してプロセスが停止しないことを確認しています。
