### PR TITLE
Fix launch file install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 # Mark other files for installation (e.g. launch and bag files, etc.)
-install(FILES
-  launch/rt_usb_9axisimu_driver.launch
+install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
aptでインストールされるROSパッケージと本リポジトリのlaunchファイルの配置を一致させます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
#35 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

`catkin_make install`を実行してlaunchファイルがlaunchディレクトリ内にあることを確認しました。

```
$ docker run --rm -it osrf/ros:melodic-desktop-full
root@64556e0b36b1:/# apt update
Get:1 http://packages.ros.org/ros/ubuntu bionic InRelease [4680 B]                                                             
Get:2 http://packages.ros.org/ros/ubuntu bionic/main amd64 Packages [744 kB]                                                             
Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]                              
Get:4 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]                         
Get:5 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [24.5 kB]        
Get:6 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1408 kB]                      
Get:7 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]                                        
Get:8 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]                                       
Get:9 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [2112 kB]              
Get:10 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]                                          
Get:11 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [395 kB]       
Get:12 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [13.5 kB]                                                                                                                         
Get:13 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1344 kB]                                                                                                                               
Get:14 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [186 kB]                                                                                                                          
Get:15 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [2182 kB]                                                                                                                   
Get:16 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [31.4 kB]                                                                                                                 
Get:17 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [425 kB]                                                                                                                  
Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [2546 kB]                                                                                                                       
Get:19 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [11.4 kB]                                                                                                                 
Get:20 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [11.3 kB]                                                                                                                     
Fetched 23.3 MB in 11s (2115 kB/s)                                                                                                                                                                         
Reading package lists... Done
Building dependency tree       
Reading state information... Done
50 packages can be upgraded. Run 'apt list --upgradable' to see them.
root@64556e0b36b1:/# apt install -y tree
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following NEW packages will be installed:
  tree
0 upgraded, 1 newly installed, 0 to remove and 50 not upgraded.
Need to get 40.7 kB of archives.
After this operation, 105 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu bionic/universe amd64 tree amd64 1.7.0-5 [40.7 kB]
Fetched 40.7 kB in 1s (42.2 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package tree.
(Reading database ... 105306 files and directories currently installed.)
Preparing to unpack .../tree_1.7.0-5_amd64.deb ...
Unpacking tree (1.7.0-5) ...
Setting up tree (1.7.0-5) ...
root@64556e0b36b1:/# mkdir -p ~/catkin_ws/src && cd $_
root@64556e0b36b1:~/catkin_ws/src# git clone -b feature/fix-launch-install-path https://github.com/rt-net/rt_usb_9axisimu_driver.git
Cloning into 'rt_usb_9axisimu_driver'...
remote: Enumerating objects: 256, done.
remote: Counting objects: 100% (14/14), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 256 (delta 3), reused 5 (delta 1), pack-reused 242
Receiving objects: 100% (256/256), 72.44 KiB | 1.13 MiB/s, done.
Resolving deltas: 100% (119/119), done.
root@64556e0b36b1:~/catkin_ws/src# rosdep install -r -y -i --from-paths .
#All required rosdeps installed successfully
root@64556e0b36b1:~/catkin_ws/src# cd ~/catkin_ws
root@64556e0b36b1:~/catkin_ws# catkin_init_workspace src
Creating symlink "/root/catkin_ws/src/CMakeLists.txt" pointing to "/opt/ros/melodic/share/catkin/cmake/toplevel.cmake"
root@64556e0b36b1:~/catkin_ws# catkin_make install
Base path: /root/catkin_ws
Source space: /root/catkin_ws/src
Build space: /root/catkin_ws/build
Devel space: /root/catkin_ws/devel
Install space: /root/catkin_ws/install
####
#### Running command: "cmake /root/catkin_ws/src -DCATKIN_DEVEL_PREFIX=/root/catkin_ws/devel -DCMAKE_INSTALL_PREFIX=/root/catkin_ws/install -G Unix Makefiles" in "/root/catkin_ws/build"
####
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CATKIN_DEVEL_PREFIX: /root/catkin_ws/devel
-- Using CMAKE_PREFIX_PATH: /opt/ros/melodic
-- This workspace overlays: /opt/ros/melodic
-- Found PythonInterp: /usr/bin/python2 (found suitable version "2.7.17", minimum required is "2") 
-- Using PYTHON_EXECUTABLE: /usr/bin/python2
-- Using Debian Python package layout
-- Using empy: /usr/bin/empy
-- Using CATKIN_ENABLE_TESTING: ON
-- Call enable_testing()
-- Using CATKIN_TEST_RESULTS_DIR: /root/catkin_ws/build/test_results
-- Found gtest sources under '/usr/src/googletest': gtests will be built
-- Found gmock sources under '/usr/src/googletest': gmock will be built
-- Found PythonInterp: /usr/bin/python2 (found version "2.7.17") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Using Python nosetests: /usr/bin/nosetests-2.7
-- catkin 0.7.29
-- BUILD_SHARED_LIBS is on
-- BUILD_SHARED_LIBS is on
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- ~~  traversing 1 packages in topological order:
-- ~~  - rt_usb_9axisimu_driver
-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- +++ processing catkin package: 'rt_usb_9axisimu_driver'
-- ==> add_subdirectory(rt_usb_9axisimu_driver)
-- Configuring done
-- Generating done
-- Build files have been written to: /root/catkin_ws/build
####
#### Running command: "make install -j6 -l6" in "/root/catkin_ws/build"
####
Scanning dependencies of target rt_usb_9axisimu_driver
[ 66%] Building CXX object rt_usb_9axisimu_driver/CMakeFiles/rt_usb_9axisimu_driver.dir/src/rt_usb_9axisimu_driver_node.cpp.o
[ 66%] Building CXX object rt_usb_9axisimu_driver/CMakeFiles/rt_usb_9axisimu_driver.dir/src/rt_usb_9axisimu_driver.cpp.o
[100%] Linking CXX executable /root/catkin_ws/devel/lib/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver
[100%] Built target rt_usb_9axisimu_driver
Install the project...
-- Install configuration: ""
-- Installing: /root/catkin_ws/install/_setup_util.py
-- Installing: /root/catkin_ws/install/env.sh
-- Installing: /root/catkin_ws/install/setup.bash
-- Installing: /root/catkin_ws/install/local_setup.bash
-- Installing: /root/catkin_ws/install/setup.sh
-- Installing: /root/catkin_ws/install/local_setup.sh
-- Installing: /root/catkin_ws/install/setup.zsh
-- Installing: /root/catkin_ws/install/local_setup.zsh
-- Installing: /root/catkin_ws/install/.rosinstall
-- Installing: /root/catkin_ws/install/lib/pkgconfig/rt_usb_9axisimu_driver.pc
-- Installing: /root/catkin_ws/install/share/rt_usb_9axisimu_driver/cmake/rt_usb_9axisimu_driverConfig.cmake
-- Installing: /root/catkin_ws/install/share/rt_usb_9axisimu_driver/cmake/rt_usb_9axisimu_driverConfig-version.cmake
-- Installing: /root/catkin_ws/install/share/rt_usb_9axisimu_driver/package.xml
-- Installing: /root/catkin_ws/install/lib/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver
-- Set runtime path of "/root/catkin_ws/install/lib/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver" to ""
-- Installing: /root/catkin_ws/install/include/rt_usb_9axisimu_driver
-- Installing: /root/catkin_ws/install/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
-- Installing: /root/catkin_ws/install/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
-- Installing: /root/catkin_ws/install/share/rt_usb_9axisimu_driver/launch
-- Installing: /root/catkin_ws/install/share/rt_usb_9axisimu_driver/launch/rt_usb_9axisimu_driver.launch
root@64556e0b36b1:~/catkin_ws# source install/setup.bash
root@64556e0b36b1:~/catkin_ws# tree $(rospack find rt_usb_9axisimu_driver)
/root/catkin_ws/install/share/rt_usb_9axisimu_driver
├── cmake
│   ├── rt_usb_9axisimu_driverConfig-version.cmake
│   └── rt_usb_9axisimu_driverConfig.cmake
├── launch
│   └── rt_usb_9axisimu_driver.launch
└── package.xml

2 directories, 4 files
root@64556e0b36b1:~/catkin_ws# 
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
