### PR TITLE
Read the latest data regardless of the operation frequency

### DIFF
--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -44,6 +44,13 @@
 #include "sensor_msgs/msg/magnetic_field.hpp"
 #include "std_msgs/msg/float64.hpp"
 
+enum class ReadStatus
+{
+  SUCCESS = 0,
+  NEED_TO_CONTINUE,
+  FAILURE
+};
+
 class RtUsb9axisimuRosDriver : public rt_usb_9axisimu::SerialPort
 {
 private:
@@ -79,7 +86,7 @@ private:
   // Method to extract binary sensor data from communication buffer
   rt_usb_9axisimu::ImuData<int16_t> extractBinarySensorData(unsigned char * imu_data_buf);
   bool isBinarySensorData(unsigned char * imu_data_buf);
-  bool readBinaryData(void);
+  ReadStatus readBinaryData(void);
   bool isValidAsciiSensorData(std::vector<std::string> imu_data_vector_buf);
   bool readAsciiData(void);
 
@@ -102,7 +109,7 @@ public:
   std::unique_ptr<sensor_msgs::msg::Imu> getImuRawDataUniquePtr(const rclcpp::Time timestamp);
   std::unique_ptr<sensor_msgs::msg::MagneticField> getImuMagUniquePtr(const rclcpp::Time timestamp);
   std::unique_ptr<std_msgs::msg::Float64> getImuTemperatureUniquePtr(void);
-  bool readSensorData();
+  ReadStatus readSensorData();
 };
 
 #endif  // RT_USB_9AXISIMU_DRIVER__RT_USB_9AXISIMU_DRIVER_HPP_

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -88,7 +88,7 @@ private:
   bool isBinarySensorData(unsigned char * imu_data_buf);
   ReadStatus readBinaryData(void);
   bool isValidAsciiSensorData(std::vector<std::string> imu_data_vector_buf);
-  bool readAsciiData(void);
+  ReadStatus readAsciiData(void);
 
 public:
   explicit RtUsb9axisimuRosDriver(std::string serialport);

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
 
@@ -93,7 +94,7 @@ bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf)
   return false;
 }
 
-bool RtUsb9axisimuRosDriver::readBinaryData(void)
+ReadStatus RtUsb9axisimuRosDriver::readBinaryData(void)
 {
   static std::vector<unsigned char> imu_binary_data_buffer;
   unsigned char read_data_buf[256];
@@ -103,14 +104,14 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
     consts.IMU_BIN_DATA_SIZE - imu_binary_data_buffer.size());
 
   if(read_data_size == 0){  // The device was unplugged.
-    return false;
+    return ReadStatus::FAILURE;
   }
 
   if(read_data_size < 0){  // read() returns error code.
     if(errno == EAGAIN || errno == EWOULDBLOCK){  // Wainting for data.
-      return true;
+      return ReadStatus::NEED_TO_CONTINUE;
     }else{
-      return false;
+      return ReadStatus::FAILURE;
     }
   }
 
@@ -119,12 +120,12 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
   }
 
   if (imu_binary_data_buffer.size() < consts.IMU_BIN_DATA_SIZE){
-    return true;
+    return ReadStatus::NEED_TO_CONTINUE;
   }
 
   if (isBinarySensorData(imu_binary_data_buffer.data()) == false) {
     imu_binary_data_buffer.clear();
-    return false;
+    return ReadStatus::FAILURE;
   }
 
   auto imu_rawdata = extractBinarySensorData(imu_binary_data_buffer.data());
@@ -134,7 +135,7 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
   sensor_data_.convertRawDataUnit();        // Convert raw data to physical quantity
   has_refreshed_imu_data_ = true;
 
-  return true;
+  return ReadStatus::SUCCESS;
 }
 
 bool RtUsb9axisimuRosDriver::isValidAsciiSensorData(std::vector<std::string> str_vector)
@@ -368,13 +369,17 @@ std::unique_ptr<std_msgs::msg::Float64> RtUsb9axisimuRosDriver::getImuTemperatur
 
 // Method to receive IMU data, convert those units to SI, and publish to ROS
 // topic
-bool RtUsb9axisimuRosDriver::readSensorData()
+ReadStatus RtUsb9axisimuRosDriver::readSensorData()
 {
   if (data_format_ == DataFormat::BINARY) {
     return readBinaryData();
   } else if (data_format_ == DataFormat::ASCII) {
-    return readAsciiData();
+    if (readAsciiData() ) {
+      return ReadStatus::SUCCESS;
+    } else {
+      return ReadStatus::FAILURE;
+    }
   }
 
-  return false;
+  return ReadStatus::FAILURE;
 }

--- a/src/rt_usb_9axisimu_driver_component.cpp
+++ b/src/rt_usb_9axisimu_driver_component.cpp
@@ -128,7 +128,7 @@ CallbackReturn Driver::on_configure(const rclcpp_lifecycle::State &)
   imu_data_raw_pub_ = create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 1);
   imu_mag_pub_ = create_publisher<sensor_msgs::msg::MagneticField>("imu/mag", 1);
   imu_temperature_pub_ = create_publisher<std_msgs::msg::Float64>("imu/temperature", 1);
-  publish_timer_ = create_wall_timer(100ms, std::bind(&Driver::on_publish_timer, this));
+  publish_timer_ = create_wall_timer(10ms, std::bind(&Driver::on_publish_timer, this));
   // Don't actually start publishing data until activated
   publish_timer_->cancel();
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#49 に関連します。

現在の実装では、IMUの最新データを受け取れるかどうかがtimerの動作周期に依存しています。
例えば、timerの周期を遅くすると最新データがほとんど取れなくなります。（遅れたデータを受信します）

https://github.com/rt-net/rt_usb_9axisimu_driver/blob/94f1714f5c4d7accc133ef28a88de07eaa864053/src/rt_usb_9axisimu_driver_component.cpp#L116

このPRでは、readを繰り返し実行し、常に最新データが取れるようにします。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#49 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

Binary、ASCIIモードで下記を確認しました。

- timerの周期を100ms、5ms、10msに変更しても常に最新データが出力されること
- on_configure時、USBが刺さっていないときにエラーを返すこと
- on_activate時、USBが刺さっていないときにエラーを返すこと
- activate中、USBを取り外すとエラーを返すこと

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
