### PR TITLE
Add unit tests

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - { ROS_DISTRO: humble, ROS_REPO: ros, BEFORE_SCRIPT: 'apt update && apt install -y git' }
+          - { ROS_DISTRO: humble, ROS_REPO: ros, AFTER_SETUP_UPSTREAM_WORKSPACE: 'apt update && apt install -y git' }
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - { ROS_DISTRO: humble, ROS_REPO: ros }
+          - { ROS_DISTRO: humble, ROS_REPO: ros, BEFORE_SCRIPT: 'apt update && apt install -y git' }
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - { ROS_DISTRO: humble, ROS_REPO: ros, AFTER_SETUP_UPSTREAM_WORKSPACE: 'apt update && apt install -y git' }
+          - { ROS_DISTRO: humble, ROS_REPO: ros, AFTER_SETUP_TARGET_WORKSPACE: 'apt update && apt install -y git' }
 
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,25 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
-#if(BUILD_TESTING)
+if(BUILD_TESTING)
 #  find_package(ament_lint_auto REQUIRED)
 #  ament_lint_auto_find_test_dependencies()
-#endif()
+  Set(FETCHCONTENT_QUIET FALSE)
+  include(FetchContent)
+  FetchContent_Declare(
+    fakeit
+    GIT_REPOSITORY https://github.com/eranpeer/FakeIt
+    GIT_TAG 2.4.0
+    GIT_PROGRESS TRUE)
+  FetchContent_MakeAvailable(fakeit)
+
+  find_package(ament_cmake_gtest)
+  ament_add_gtest(test_driver test/test_driver.cpp src/rt_usb_9axisimu_driver.cpp)
+  target_include_directories(test_driver PRIVATE ${fakeit_SOURCE_DIR}/single_header/gtest)
+  ament_target_dependencies(test_driver
+    rclcpp
+    sensor_msgs
+  )
+endif()
 
 ament_package()

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
@@ -165,7 +165,19 @@ public:
  *
  **********************************************************************************************************/
 
-class SerialPort
+class SerialPortInterface
+{
+public:
+  virtual ~SerialPortInterface() {}
+  virtual void setPort(const char * port) = 0;
+  virtual bool openPort(const char * port) = 0;
+  virtual bool openSerialPort() = 0;
+  virtual void closeSerialPort() = 0;
+  virtual int readFromDevice(unsigned char * buf, unsigned int buf_len) = 0;
+  virtual int writeToDevice(unsigned char * data, unsigned int data_len) = 0;
+};
+
+class SerialPort : public SerialPortInterface
 {
 private:
   std::string port_name_;  // ex) "/dev/ttyACM0"

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
@@ -165,19 +165,7 @@ public:
  *
  **********************************************************************************************************/
 
-class SerialPortInterface
-{
-public:
-  virtual ~SerialPortInterface() {}
-  virtual void setPort(const char * port) = 0;
-  virtual bool openPort(const char * port) = 0;
-  virtual bool openSerialPort() = 0;
-  virtual void closeSerialPort() = 0;
-  virtual int readFromDevice(unsigned char * buf, unsigned int buf_len) = 0;
-  virtual int writeToDevice(unsigned char * data, unsigned int data_len) = 0;
-};
-
-class SerialPort : public SerialPortInterface
+class SerialPort
 {
 private:
   std::string port_name_;  // ex) "/dev/ttyACM0"
@@ -190,23 +178,23 @@ public:
   {
   }
 
-  ~SerialPort()
+  virtual ~SerialPort()
   {
     closeSerialPort();
   }
 
-  void setPort(const char * port)
+  virtual void setPort(const char * port)
   {
     port_name_ = port;
   }
 
-  bool openPort(const char * port)
+  virtual bool openPort(const char * port)
   {
     port_name_ = port;
     return openSerialPort();
   }
 
-  bool openSerialPort()
+  virtual bool openSerialPort()
   {
     int fd = 0;
 
@@ -233,7 +221,7 @@ public:
     return fd > 0;
   }
 
-  void closeSerialPort()
+  virtual void closeSerialPort()
   {
     if (port_fd_ > 0) {
       tcsetattr(port_fd_, TCSANOW, &old_settings_);
@@ -242,7 +230,7 @@ public:
     }
   }
 
-  int readFromDevice(unsigned char * buf, unsigned int buf_len)
+  virtual int readFromDevice(unsigned char * buf, unsigned int buf_len)
   {
     if (port_fd_ < 0) {
       return -1;
@@ -251,7 +239,7 @@ public:
     return read(port_fd_, buf, buf_len);
   }
 
-  int writeToDevice(unsigned char * data, unsigned int data_len)
+  virtual int writeToDevice(unsigned char * data, unsigned int data_len)
   {
     if (port_fd_ < 0) {
       return -1;

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -47,7 +47,7 @@
 class RtUsb9axisimuRosDriver
 {
 private:
-  std::unique_ptr<rt_usb_9axisimu::SerialPortInterface> serial_port_;
+  std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port_;
 
   rt_usb_9axisimu::SensorData sensor_data_;
 
@@ -81,7 +81,7 @@ private:
 
 public:
   explicit RtUsb9axisimuRosDriver(std::string serialport);
-  RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPortInterface> serial_port, std::string port_name);
+  RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port);
   ~RtUsb9axisimuRosDriver();
 
   void setImuFrameIdName(std::string frame_id);

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -47,7 +47,7 @@
 class RtUsb9axisimuRosDriver
 {
 private:
-  std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port_;
+  std::unique_ptr<rt_usb_9axisimu::SerialPortInterface> serial_port_;
 
   rt_usb_9axisimu::SensorData sensor_data_;
 
@@ -81,7 +81,7 @@ private:
 
 public:
   explicit RtUsb9axisimuRosDriver(std::string serialport);
-  RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port, std::string port_name);
+  RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPortInterface> serial_port, std::string port_name);
   ~RtUsb9axisimuRosDriver();
 
   void setImuFrameIdName(std::string frame_id);

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -44,14 +44,10 @@
 #include "sensor_msgs/msg/magnetic_field.hpp"
 #include "std_msgs/msg/float64.hpp"
 
-class RtUsb9axisimuRosDriver : public rt_usb_9axisimu::SerialPort
+class RtUsb9axisimuRosDriver
 {
 private:
-  // ros::NodeHandle nh_;
-
-  // ros::Publisher imu_data_raw_pub_;
-  // ros::Publisher imu_mag_pub_;
-  // ros::Publisher imu_temperature_pub_;
+  std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port_;
 
   rt_usb_9axisimu::SensorData sensor_data_;
 
@@ -85,6 +81,7 @@ private:
 
 public:
   explicit RtUsb9axisimuRosDriver(std::string serialport);
+  RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port, std::string port_name);
   ~RtUsb9axisimuRosDriver();
 
   void setImuFrameIdName(std::string frame_id);

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -99,7 +99,7 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
   unsigned char read_data_buf[256];
 
   has_refreshed_imu_data_ = false;
-  int read_data_size = readFromDevice(read_data_buf,
+  int read_data_size = serial_port_->readFromDevice(read_data_buf,
     consts.IMU_BIN_DATA_SIZE - imu_binary_data_buffer.size());
 
   if(read_data_size == 0){  // The device was unplugged.
@@ -158,7 +158,7 @@ bool RtUsb9axisimuRosDriver::readAsciiData(void)
   has_refreshed_imu_data_ = false;
   imu_data_oneline_buf.clear();
 
-  int data_size_of_buf = readFromDevice(imu_data_buf, sizeof(imu_data_buf));
+  int data_size_of_buf = serial_port_->readFromDevice(imu_data_buf, sizeof(imu_data_buf));
 
   if (data_size_of_buf <= 0) {
     return false;  // Raise communication error
@@ -205,8 +205,17 @@ bool RtUsb9axisimuRosDriver::readAsciiData(void)
 }
 
 RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::string port = "")
-: rt_usb_9axisimu::SerialPort(port.c_str())
 {
+  serial_port_ = std::make_unique<rt_usb_9axisimu::SerialPort>(port.c_str());
+  has_completed_format_check_ = false;
+  data_format_ = DataFormat::NONE;
+  has_refreshed_imu_data_ = false;
+}
+
+RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port, std::string port_name)
+{
+  serial_port_ = std::move(serial_port);
+  serial_port_->setPort(port_name.c_str());
   has_completed_format_check_ = false;
   data_format_ = DataFormat::NONE;
   has_refreshed_imu_data_ = false;
@@ -223,7 +232,7 @@ void RtUsb9axisimuRosDriver::setImuFrameIdName(std::string frame_id)
 
 void RtUsb9axisimuRosDriver::setImuPortName(std::string port)
 {
-  setPort(port.c_str());
+  serial_port_->setPort(port.c_str());
 }
 
 void RtUsb9axisimuRosDriver::setImuStdDev(
@@ -238,12 +247,12 @@ void RtUsb9axisimuRosDriver::setImuStdDev(
 bool RtUsb9axisimuRosDriver::startCommunication()
 {
   // returns serial port open status
-  return openSerialPort();
+  return serial_port_->openSerialPort();
 }
 
 void RtUsb9axisimuRosDriver::stopCommunication(void)
 {
-  closeSerialPort();
+  serial_port_->closeSerialPort();
   has_completed_format_check_ = false;
   data_format_ = DataFormat::NONE;
   has_refreshed_imu_data_ = false;
@@ -253,7 +262,7 @@ void RtUsb9axisimuRosDriver::checkDataFormat(void)
 {
   if (data_format_ == DataFormat::NONE) {
     unsigned char data_buf[256];
-    int data_size_of_buf = readFromDevice(data_buf, consts.IMU_BIN_DATA_SIZE);
+    int data_size_of_buf = serial_port_->readFromDevice(data_buf, consts.IMU_BIN_DATA_SIZE);
     if (data_size_of_buf == consts.IMU_BIN_DATA_SIZE) {
       if (isBinarySensorData(data_buf)) {
         data_format_ = DataFormat::BINARY;

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -212,10 +212,9 @@ RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::string port = "")
   has_refreshed_imu_data_ = false;
 }
 
-RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPortInterface> serial_port, std::string port_name)
+RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port)
 {
   serial_port_ = std::move(serial_port);
-  serial_port_->setPort(port_name.c_str());
   has_completed_format_check_ = false;
   data_format_ = DataFormat::NONE;
   has_refreshed_imu_data_ = false;

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -212,7 +212,7 @@ RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::string port = "")
   has_refreshed_imu_data_ = false;
 }
 
-RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port, std::string port_name)
+RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPortInterface> serial_port, std::string port_name)
 {
   serial_port_ = std::move(serial_port);
   serial_port_->setPort(port_name.c_str());

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -1,30 +1,65 @@
+/*
+ * test_driver.cpp
+ *
+ * License: BSD-3-Clause
+ *
+ * Copyright (c) 2015-2023 RT Corporation <support@rt-net.jp>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of RT Corporation nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include <gtest/gtest.h>
+#include "fakeit.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp"
 
-#include "fakeit.hpp"
-using namespace fakeit;
-using namespace rt_usb_9axisimu;
+using fakeit::Mock;
+using fakeit::When;
+using rt_usb_9axisimu::SerialPort;
+
+Mock<SerialPort> create_serial_port_mock(void) {
+  Mock<SerialPort> mock;
+  When(Method(mock, setPort)).AlwaysReturn();
+  When(Method(mock, openPort)).AlwaysReturn(true);
+  When(Method(mock, openSerialPort)).AlwaysReturn(true);
+  When(Method(mock, closeSerialPort)).AlwaysReturn();
+  When(Method(mock, readFromDevice)).AlwaysReturn(0);
+  When(Method(mock, writeToDevice)).AlwaysReturn(0);
+  return mock;
+}
 
 TEST(TestDriver, startCommunication)
 {
-  // Mock settings
-  // TODO(ShotAk): Use test fixture
-  Mock<SerialPortInterface> mock;
-  When(Method(mock, setPort).Using(Any())).AlwaysReturn();
-  When(Method(mock, openPort)).Return(true);
-  When(Method(mock, openSerialPort)).Return(true);
-  When(Method(mock, closeSerialPort));
-  When(Method(mock, readFromDevice)).AlwaysReturn(0);
-  When(Method(mock, writeToDevice)).AlwaysReturn(0);
+  // Expect the startCommunication method to be called twice and return true then false
+  auto mock = create_serial_port_mock();
+  When(Method(mock, openSerialPort)).Return(true, false);  // Return true then false
 
-  // Set mock method for this test
-  When(Method(mock, openSerialPort)).Return(true, false);
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
 
-  std::unique_ptr<SerialPortInterface> mock_ptr(&mock.get());
-  RtUsb9axisimuRosDriver driver(std::move(mock_ptr), "/dev/ttyUSB0");
-
-  EXPECT_EQ(driver.startCommunication(), true);
-  EXPECT_EQ(driver.startCommunication(), false);
+  EXPECT_TRUE(driver.startCommunication());
+  EXPECT_FALSE(driver.startCommunication());
 }

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -1,0 +1,30 @@
+
+#include <gtest/gtest.h>
+#include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
+#include "rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp"
+
+#include "fakeit.hpp"
+using namespace fakeit;
+using namespace rt_usb_9axisimu;
+
+TEST(TestDriver, startCommunication)
+{
+  // Mock settings
+  // TODO(ShotAk): Use test fixture
+  Mock<SerialPortInterface> mock;
+  When(Method(mock, setPort).Using(Any())).AlwaysReturn();
+  When(Method(mock, openPort)).Return(true);
+  When(Method(mock, openSerialPort)).Return(true);
+  When(Method(mock, closeSerialPort));
+  When(Method(mock, readFromDevice)).AlwaysReturn(0);
+  When(Method(mock, writeToDevice)).AlwaysReturn(0);
+
+  // Set mock method for this test
+  When(Method(mock, openSerialPort)).Return(true, false);
+
+  std::unique_ptr<SerialPortInterface> mock_ptr(&mock.get());
+  RtUsb9axisimuRosDriver driver(std::move(mock_ptr), "/dev/ttyUSB0");
+
+  EXPECT_EQ(driver.startCommunication(), true);
+  EXPECT_EQ(driver.startCommunication(), false);
+}

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -145,9 +145,35 @@ TEST(TestDriver, checkDataFormat_ASCII)
     std::unique_ptr<SerialPort>(&mock.get()));
 
   driver.checkDataFormat();
-  driver.checkDataFormat();
 
   EXPECT_TRUE(driver.hasCompletedFormatCheck());
   EXPECT_TRUE(driver.hasAsciiDataFormat());
   EXPECT_FALSE(driver.hasBinaryDataFormat());
+}
+
+TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
+{
+  // Expect to check correctly when read data in not Binary or ASCII format
+  auto mock = create_serial_port_mock();
+
+  When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    rt_usb_9axisimu::Consts consts;
+    unsigned char dummy_data_not_binary_or_ascii[] =
+      "dummy_data_not_binary_or_ascii";
+    for(int i = 0; i < int(sizeof(dummy_data_not_binary_or_ascii)); i++) {
+      buf[i] = dummy_data_not_binary_or_ascii[i];
+    }
+    buf_size = consts.IMU_BIN_DATA_SIZE;
+    return buf_size;
+  });
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  driver.checkDataFormat();
+
+  EXPECT_FALSE(driver.hasCompletedFormatCheck());
+  EXPECT_FALSE(driver.hasBinaryDataFormat());
+  EXPECT_FALSE(driver.hasAsciiDataFormat());
 }

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -63,3 +63,17 @@ TEST(TestDriver, startCommunication)
   EXPECT_TRUE(driver.startCommunication());
   EXPECT_FALSE(driver.startCommunication());
 }
+
+TEST(TestDriver, initialize_member_variables)
+{
+  // Expect member variables of the driver instance to be initialised
+  auto mock = create_serial_port_mock();
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  EXPECT_FALSE(driver.hasCompletedFormatCheck());
+  EXPECT_FALSE(driver.hasBinaryDataFormat());
+  EXPECT_FALSE(driver.hasAsciiDataFormat());
+  EXPECT_FALSE(driver.hasRefreshedImuData());
+}

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -145,6 +145,7 @@ TEST(TestDriver, checkDataFormat_ASCII)
     std::unique_ptr<SerialPort>(&mock.get()));
 
   driver.checkDataFormat();
+  driver.checkDataFormat();
 
   EXPECT_TRUE(driver.hasCompletedFormatCheck());
   EXPECT_TRUE(driver.hasAsciiDataFormat());

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -77,3 +77,32 @@ TEST(TestDriver, initialize_member_variables)
   EXPECT_FALSE(driver.hasAsciiDataFormat());
   EXPECT_FALSE(driver.hasRefreshedImuData());
 }
+
+TEST(TestDriver, checkDataFormat_Binary)
+{
+  // Expect to check correctly when read data in binary format
+  auto mock = create_serial_port_mock();
+
+  When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    rt_usb_9axisimu::Consts consts;
+    unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x52; // R
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x54; // T
+
+    for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
+      buf[i] = dummy_bin_imu_data[i];
+    }
+    buf_size = consts.IMU_BIN_DATA_SIZE;
+    return buf_size;
+  });
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  driver.checkDataFormat();
+
+  EXPECT_TRUE(driver.hasCompletedFormatCheck());
+  EXPECT_TRUE(driver.hasBinaryDataFormat());
+  EXPECT_FALSE(driver.hasAsciiDataFormat());
+}

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <array>
+#include <string>
 #include <gtest/gtest.h>
 #include "fakeit.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
@@ -89,7 +91,6 @@ TEST(TestDriver, checkDataFormat_Binary)
     unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
     dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x52; // R
     dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x54; // T
-
     for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
       buf[i] = dummy_bin_imu_data[i];
     }
@@ -105,4 +106,48 @@ TEST(TestDriver, checkDataFormat_Binary)
   EXPECT_TRUE(driver.hasCompletedFormatCheck());
   EXPECT_TRUE(driver.hasBinaryDataFormat());
   EXPECT_FALSE(driver.hasAsciiDataFormat());
+}
+
+TEST(TestDriver, checkDataFormat_ASCII)
+{
+  // Expect to check correctly when read data in ASCII format
+  auto mock = create_serial_port_mock();
+
+  When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    rt_usb_9axisimu::Consts consts;
+    std::array<std::string, consts.IMU_ASCII_DATA_SIZE> dummy_ascii_imu_data; 
+    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
+    std::string str = "";
+    std::string split_char = ",";
+    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
+      str += dummy_ascii_imu_data[i];
+      if(i != consts.IMU_ASCII_DATA_SIZE - 1) str += split_char;
+    }
+    for(int i = 0; i < int(str.length()); i++) {
+      buf[i] = str[i];
+    }
+    buf_size = consts.IMU_BIN_DATA_SIZE;
+    return buf_size;
+  });
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  driver.checkDataFormat();
+  driver.checkDataFormat();
+
+  EXPECT_TRUE(driver.hasCompletedFormatCheck());
+  EXPECT_TRUE(driver.hasAsciiDataFormat());
+  EXPECT_FALSE(driver.hasBinaryDataFormat());
 }


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
9軸IMUのROS 2パッケージに、テスト環境の構築が可能か確認するための単体テストを追加します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
ローカル環境でcolcon buildとcolcon testが通ることを確認しました。

下記の手順で実機の9軸IMUからデータが取得できることを確認しました。

パッケージのインストール
```sh
mkdir -p ~/imu_ws/src
cd ~/imu_ws/src
git clone -b add_unit_test https://github.com/rt-net/rt_usb_9axisimu_driver.git
cd ~/imu_ws
colcon build --symlink-install
```

9軸IMUをUSBケーブルで接続

端末1
```sh
source ~/imu_ws/install/setup.bash
ros2 run rt_usb_9axisimu_driver rt_usb_9axisimu_driver
# [INFO] [1712302931.150554866] [rt_usb_9axisimu_driver]: on_configure() is called.
# [INFO] [1712302931.154430563] [rt_usb_9axisimu_driver]: Format check has completed.
# [INFO] [1712302931.154481850] [rt_usb_9axisimu_driver]: Data format is ascii.
# [INFO] [1712303046.004763387] [rt_usb_9axisimu_driver]: on_activate() is called.
```

端末2
```sh
source ~/imu_ws/install/setup.bash
ros2 lifecycle set rt_usb_9axisimu_driver configure
# Transitioning successful
ros2 lifecycle set rt_usb_9axisimu_driver activate
# Transitioning successful
ros2 topic echo /imu/data_raw
# トピックの配信を確認OK
ros2 topic echo /imu/mag
# トピックの配信を確認OK
ros2 topic echo /imu/temperature
# data: 35.32593536376953
```

# Any other comments?
<!-- その他コメントはありますか？ -->
なし。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
