### PR TITLE
checkDataFormat() and unit test updates

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -19,6 +19,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: "ros-industrial/industrial_ci@master"
         env: ${{ matrix.env }}

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
@@ -106,6 +106,8 @@ public:
     IMU_ASCII_DATA_SIZE
   };
 
+  static constexpr int READ_BUFFER_SIZE = 256;
+
   // Convertor
   const double CONVERTOR_RAW2G;
   const double CONVERTOR_RAW2DPS;

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -57,6 +57,11 @@ private:
   double magnetic_field_stddev_;
   rt_usb_9axisimu::Consts consts;
 
+  unsigned char bin_read_buffer[256];
+  unsigned char ascii_read_buffer[256];
+  unsigned int bin_read_buffer_idx = 0;
+  unsigned int ascii_read_buffer_idx = 0;
+
   enum DataFormat
   {
     NONE = 0,
@@ -73,9 +78,9 @@ private:
   int16_t combineByteData(unsigned char data_h, unsigned char data_l);
   // Method to extract binary sensor data from communication buffer
   rt_usb_9axisimu::ImuData<int16_t> extractBinarySensorData(unsigned char * imu_data_buf);
-  bool isBinarySensorData(unsigned char * imu_data_buf);
+  bool isBinarySensorData(unsigned char * imu_data_buf, unsigned int data_size);
   bool readBinaryData(void);
-  bool isAsciiSensorData(unsigned char * imu_data_buf, int data_size);
+  bool isAsciiSensorData(unsigned char * imu_data_buf, unsigned int data_size);
   bool isValidAsciiSensorData(std::vector<std::string> imu_data_vector_buf);
   bool readAsciiData(void);
 

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -76,6 +76,7 @@ private:
   rt_usb_9axisimu::ImuData<int16_t> extractBinarySensorData(unsigned char * imu_data_buf);
   bool isBinarySensorData(unsigned char * imu_data_buf);
   bool readBinaryData(void);
+  bool isAsciiSensorData(unsigned char * imu_data_buf, int data_size);
   bool isValidAsciiSensorData(std::vector<std::string> imu_data_vector_buf);
   bool readAsciiData(void);
 

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -57,10 +57,10 @@ private:
   double magnetic_field_stddev_;
   rt_usb_9axisimu::Consts consts;
 
-  unsigned char bin_read_buffer[256];
-  unsigned char ascii_read_buffer[256];
-  unsigned int bin_read_buffer_idx = 0;
-  unsigned int ascii_read_buffer_idx = 0;
+  unsigned char bin_read_buffer_[rt_usb_9axisimu::Consts::READ_BUFFER_SIZE];
+  unsigned char ascii_read_buffer_[rt_usb_9axisimu::Consts::READ_BUFFER_SIZE];
+  unsigned int bin_read_buffer_idx_ = 0;
+  unsigned int ascii_read_buffer_idx_ = 0;
 
   enum DataFormat
   {

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -66,7 +66,6 @@ private:
     ASCII,
     INCORRECT
   };
-  bool has_completed_format_check_;
   DataFormat data_format_;
   bool has_refreshed_imu_data_;
 
@@ -91,8 +90,7 @@ public:
 
   bool startCommunication();
   void stopCommunication(void);
-  void checkDataFormat(void);
-  bool hasCompletedFormatCheck(void);
+  void checkDataFormat(const double timeout = 5.0);
   bool hasAsciiDataFormat(void);
   bool hasBinaryDataFormat(void);
   bool hasRefreshedImuData(void);

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -87,8 +87,12 @@ RtUsb9axisimuRosDriver::extractBinarySensorData(unsigned char * imu_data_buf)
 
 bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf)
 {
-  if (imu_data_buf[consts.IMU_BIN_HEADER_R] == 'R' &&
-    imu_data_buf[consts.IMU_BIN_HEADER_T] == 'T')
+  if (imu_data_buf[consts.IMU_BIN_HEADER_FF0] == 0xff &&
+    imu_data_buf[consts.IMU_BIN_HEADER_FF1] == 0xff &&
+    imu_data_buf[consts.IMU_BIN_HEADER_R] == 'R' &&
+    imu_data_buf[consts.IMU_BIN_HEADER_T] == 'T' &&
+    imu_data_buf[consts.IMU_BIN_HEADER_ID0] == 0x39 &&
+    imu_data_buf[consts.IMU_BIN_HEADER_ID1] == 0x41)
   {
     return true;
   }
@@ -137,6 +141,32 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
   has_refreshed_imu_data_ = true;
 
   return true;
+}
+
+bool RtUsb9axisimuRosDriver::isAsciiSensorData(unsigned char * imu_data_buf, int data_size)
+{
+  // convert imu data to vector in ascii format
+  static std::vector<std::string> data_vector_ascii;
+  std::string data_oneline_ascii;
+  for (int char_count = 0; char_count < data_size; char_count++) {
+    if (imu_data_buf[char_count] == ',' || imu_data_buf[char_count] == '\n') {
+      data_vector_ascii.push_back(data_oneline_ascii);
+      data_oneline_ascii.clear();
+    } else {
+      data_oneline_ascii += imu_data_buf[char_count];
+    }
+    if (imu_data_buf[char_count] == '\n') {
+      break;
+    }
+  }
+
+  // check data is in ascii format
+  if (data_vector_ascii.size() == consts.IMU_ASCII_DATA_SIZE &&
+    data_vector_ascii[consts.IMU_ASCII_TIMESTAMP].find(".") == std::string::npos &&
+    isValidAsciiSensorData(data_vector_ascii)) {
+    return true;
+  }
+  return false;
 }
 
 bool RtUsb9axisimuRosDriver::isValidAsciiSensorData(std::vector<std::string> str_vector)
@@ -262,58 +292,26 @@ void RtUsb9axisimuRosDriver::stopCommunication(void)
 void RtUsb9axisimuRosDriver::checkDataFormat(void)
 {
   if (data_format_ == DataFormat::NONE) {
-    // read data in binary format
-    unsigned char data_buf_binary[consts.IMU_BIN_DATA_SIZE];
-    int data_size_binary = serial_port_->readFromDevice(data_buf_binary, consts.IMU_BIN_DATA_SIZE);
+    unsigned char read_buffer[256];
+    int read_size = serial_port_->readFromDevice(read_buffer, sizeof(read_buffer));
 
-    // read data in ascii format
-    unsigned char data_buf_ascii[256];
-    int data_size_ascii = serial_port_->readFromDevice(data_buf_ascii, sizeof(data_buf_ascii));
-
-    // convert ascii data to vector
-    static std::vector<std::string> data_vector_ascii;
-    std::string data_oneline_ascii;
-    for (int char_count = 0; char_count < data_size_ascii; char_count++) {
-      if (data_buf_ascii[char_count] == ',' || data_buf_ascii[char_count] == '\n') {
-        data_vector_ascii.push_back(data_oneline_ascii);
-        data_oneline_ascii.clear();
-      } else {
-        data_oneline_ascii += data_buf_ascii[char_count];
-      }
-      if (data_buf_ascii[char_count] == '\n') {
-        break;
-      }
+    if(read_size <= 0) {
+      data_format_ = DataFormat::NONE;
+      has_completed_format_check_ = false;
+      return;
     }
 
-    // debug
-    std::cout << "--- debug start ---" << std::endl;;
-    for(int i = 0; i < (int)sizeof(data_buf_ascii); i++) {
-      std::cout << data_buf_ascii[i];
+    if (isBinarySensorData(read_buffer)) {
+      data_format_ = DataFormat::BINARY;
+      has_completed_format_check_ = true;
     }
-    std::cout << std::endl;
-    std::cout << data_size_ascii << std::endl;;
-    std::cout << data_vector_ascii.size() << std::endl;;
-    std::cout << "--- debug start ---" << std::endl;;
-
-    // check data format
-    if (data_size_binary == consts.IMU_BIN_DATA_SIZE) {
-      if (isBinarySensorData(data_buf_binary)) {
-        data_format_ = DataFormat::BINARY;
-        has_completed_format_check_ = true;
-      } else {
-        data_format_ = DataFormat::NOT_BINARY;
-        has_completed_format_check_ = true;
-      }
+    else if (isAsciiSensorData(read_buffer, read_size)) {
+      data_format_ = DataFormat::ASCII;
+      has_completed_format_check_ = true;
     }
-    if (data_vector_ascii.size() == consts.IMU_ASCII_DATA_SIZE) {
-      if (data_vector_ascii[consts.IMU_ASCII_TIMESTAMP].find(".") == std::string::npos &&
-        isValidAsciiSensorData(data_vector_ascii)) {
-        data_format_ = DataFormat::ASCII;
-        has_completed_format_check_ = true;
-      } else {
-        data_format_ = DataFormat::NOT_ASCII;
-        has_completed_format_check_ = true;
-      }
+    else {
+      data_format_ = DataFormat::NONE;
+      has_completed_format_check_ = false;
     }
   }
 }

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -82,14 +82,28 @@ RtUsb9axisimuRosDriver::extractBinarySensorData(unsigned char * imu_data_buf)
   return imu_rawdata;
 }
 
-bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf)
+bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf, unsigned int data_size)
 {
-  if (imu_data_buf[consts.IMU_BIN_HEADER_FF0] == 0xff &&
-    imu_data_buf[consts.IMU_BIN_HEADER_FF1] == 0xff &&
-    imu_data_buf[consts.IMU_BIN_HEADER_R] == 'R' &&
-    imu_data_buf[consts.IMU_BIN_HEADER_T] == 'T' &&
-    imu_data_buf[consts.IMU_BIN_HEADER_ID0] == 0x39 &&
-    imu_data_buf[consts.IMU_BIN_HEADER_ID1] == 0x41)
+  for (int i = 0; i < (int)data_size; i++) {
+    if (bin_read_buffer_idx >= 256) break;
+    bin_read_buffer[bin_read_buffer_idx] = imu_data_buf[i];
+    bin_read_buffer_idx++;
+  }
+
+  int start_idx = 0;
+  for (int i = 0; i < (int)(bin_read_buffer_idx - consts.IMU_BIN_DATA_SIZE); i++) {
+    if (imu_data_buf[i] == 0xff) {
+      start_idx = i;
+      break;
+    }
+  }
+
+  if (imu_data_buf[start_idx + consts.IMU_BIN_HEADER_FF0] == 0xff &&
+    imu_data_buf[start_idx + consts.IMU_BIN_HEADER_FF1] == 0xff &&
+    imu_data_buf[start_idx + consts.IMU_BIN_HEADER_R] == 'R' &&
+    imu_data_buf[start_idx + consts.IMU_BIN_HEADER_T] == 'T' &&
+    imu_data_buf[start_idx + consts.IMU_BIN_HEADER_ID0] == 0x39 &&
+    imu_data_buf[start_idx + consts.IMU_BIN_HEADER_ID1] == 0x41)
   {
     return true;
   }
@@ -125,7 +139,7 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
     return true;
   }
 
-  if (isBinarySensorData(imu_binary_data_buffer.data()) == false) {
+  if (isBinarySensorData(imu_binary_data_buffer.data(), imu_binary_data_buffer.size()) == false) {
     imu_binary_data_buffer.clear();
     return false;
   }
@@ -140,28 +154,40 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
   return true;
 }
 
-bool RtUsb9axisimuRosDriver::isAsciiSensorData(unsigned char * imu_data_buf, int data_size)
+bool RtUsb9axisimuRosDriver::isAsciiSensorData(unsigned char * imu_data_buf, unsigned int data_size)
 {
+  for (int i = 0; i < (int)data_size; i++) {
+    if (ascii_read_buffer_idx >= 256) break;
+    ascii_read_buffer[ascii_read_buffer_idx] = imu_data_buf[i];
+    ascii_read_buffer_idx++;
+  }
+
   // convert imu data to vector in ascii format
-  std::vector<std::string> data_vector_ascii;
+  std::vector<std::vector<std::string>> data_vector_ascii;
+  std::vector<std::string> data_oneset_ascii;
   std::string data_oneline_ascii;
-  for (int char_count = 0; char_count < data_size; char_count++) {
-    if (imu_data_buf[char_count] == ',' || imu_data_buf[char_count] == '\n') {
-      data_vector_ascii.push_back(data_oneline_ascii);
+  for (int char_count = 0; char_count < (int)ascii_read_buffer_idx; char_count++) {
+    if (ascii_read_buffer[char_count] == '\n') {
+      data_oneset_ascii.push_back(data_oneline_ascii);
+      data_vector_ascii.push_back(data_oneset_ascii);
+      data_oneline_ascii.clear();
+      data_oneset_ascii.clear();
+    }
+    else if (ascii_read_buffer[char_count] == ',') {
+      data_oneset_ascii.push_back(data_oneline_ascii);
       data_oneline_ascii.clear();
     } else {
-      data_oneline_ascii += imu_data_buf[char_count];
-    }
-    if (imu_data_buf[char_count] == '\n') {
-      break;
+      data_oneline_ascii += ascii_read_buffer[char_count];
     }
   }
 
   // check data is in ascii format
-  if (data_vector_ascii.size() == consts.IMU_ASCII_DATA_SIZE &&
-    data_vector_ascii[consts.IMU_ASCII_TIMESTAMP].find(".") == std::string::npos &&
-    isValidAsciiSensorData(data_vector_ascii)) {
-    return true;
+  for (int i = 0; i < (int)data_vector_ascii.size(); i++) {
+    if (data_vector_ascii.at(i).size() == consts.IMU_ASCII_DATA_SIZE &&
+      data_vector_ascii.at(i).at(consts.IMU_ASCII_TIMESTAMP).find(".") == std::string::npos &&
+      isValidAsciiSensorData(data_vector_ascii.at(i))) {
+      return true;
+    }
   }
   return false;
 }
@@ -296,11 +322,11 @@ void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
     unsigned char read_buffer[256];
     const auto read_size = serial_port_->readFromDevice(read_buffer, sizeof(read_buffer));
 
-    if(read_size <= 0) {
+    if (read_size <= 0) {
       continue;
     }
 
-    if (isBinarySensorData(read_buffer)) {
+    if (isBinarySensorData(read_buffer, read_size)) {
       data_format_ = DataFormat::BINARY;
       return;
     }

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -35,7 +35,6 @@
 #include <utility>
 #include <vector>
 #include <chrono>
-#include <thread>
 
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
 
@@ -288,10 +287,6 @@ void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
 {
   auto start_time = std::chrono::system_clock::now();
   while (data_format_ == DataFormat::NONE) {
-    // sleep (10ms)
-    // Prevent read failures due to high speed loop processing
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
     // time out (default 5.0s)
     // Measures for data formats that are neither Binary nor ASCII
     auto end_time = std::chrono::system_clock::now();

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -31,13 +31,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <iostream>
-
-#include <cstring>
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
+#include <chrono>
 
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
 
@@ -146,7 +143,7 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
 bool RtUsb9axisimuRosDriver::isAsciiSensorData(unsigned char * imu_data_buf, int data_size)
 {
   // convert imu data to vector in ascii format
-  static std::vector<std::string> data_vector_ascii;
+  std::vector<std::string> data_vector_ascii;
   std::string data_oneline_ascii;
   for (int char_count = 0; char_count < data_size; char_count++) {
     if (imu_data_buf[char_count] == ',' || imu_data_buf[char_count] == '\n') {
@@ -239,7 +236,6 @@ bool RtUsb9axisimuRosDriver::readAsciiData(void)
 RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::string port = "")
 {
   serial_port_ = std::make_unique<rt_usb_9axisimu::SerialPort>(port.c_str());
-  has_completed_format_check_ = false;
   data_format_ = DataFormat::NONE;
   has_refreshed_imu_data_ = false;
 }
@@ -247,7 +243,6 @@ RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::string port = "")
 RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port)
 {
   serial_port_ = std::move(serial_port);
-  has_completed_format_check_ = false;
   data_format_ = DataFormat::NONE;
   has_refreshed_imu_data_ = false;
 }
@@ -284,41 +279,37 @@ bool RtUsb9axisimuRosDriver::startCommunication()
 void RtUsb9axisimuRosDriver::stopCommunication(void)
 {
   serial_port_->closeSerialPort();
-  has_completed_format_check_ = false;
   data_format_ = DataFormat::NONE;
   has_refreshed_imu_data_ = false;
 }
 
-void RtUsb9axisimuRosDriver::checkDataFormat(void)
+void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
 {
-  if (data_format_ == DataFormat::NONE) {
+  auto start_time = std::chrono::system_clock::now();
+  while (data_format_ == DataFormat::NONE) {
+    // time out
+    auto end_time = std::chrono::system_clock::now();
+    double time_elapsed = (double)std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
+    if (time_elapsed > timeout) {
+      return;
+    }
+    
     unsigned char read_buffer[256];
     int read_size = serial_port_->readFromDevice(read_buffer, sizeof(read_buffer));
 
     if(read_size <= 0) {
-      data_format_ = DataFormat::NONE;
-      has_completed_format_check_ = false;
-      return;
+      continue;
     }
 
     if (isBinarySensorData(read_buffer)) {
       data_format_ = DataFormat::BINARY;
-      has_completed_format_check_ = true;
+      return;
     }
     else if (isAsciiSensorData(read_buffer, read_size)) {
       data_format_ = DataFormat::ASCII;
-      has_completed_format_check_ = true;
-    }
-    else {
-      data_format_ = DataFormat::NONE;
-      has_completed_format_check_ = false;
+      return;
     }
   }
-}
-
-bool RtUsb9axisimuRosDriver::hasCompletedFormatCheck(void)
-{
-  return has_completed_format_check_;
 }
 
 bool RtUsb9axisimuRosDriver::hasAsciiDataFormat(void)

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -85,9 +85,9 @@ RtUsb9axisimuRosDriver::extractBinarySensorData(unsigned char * imu_data_buf)
 bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf, unsigned int data_size)
 {
   for (int i = 0; i < (int)data_size; i++) {
-    if (bin_read_buffer_idx >= 256) break;
     bin_read_buffer[bin_read_buffer_idx] = imu_data_buf[i];
     bin_read_buffer_idx++;
+    if (bin_read_buffer_idx >= 256) bin_read_buffer_idx = 0;
   }
 
   int start_idx = 0;
@@ -157,9 +157,9 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
 bool RtUsb9axisimuRosDriver::isAsciiSensorData(unsigned char * imu_data_buf, unsigned int data_size)
 {
   for (int i = 0; i < (int)data_size; i++) {
-    if (ascii_read_buffer_idx >= 256) break;
     ascii_read_buffer[ascii_read_buffer_idx] = imu_data_buf[i];
     ascii_read_buffer_idx++;
+    if (ascii_read_buffer_idx >= 256) ascii_read_buffer_idx = 0;
   }
 
   // convert imu data to vector in ascii format

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -287,8 +287,6 @@ void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
 {
   auto start_time = std::chrono::system_clock::now();
   while (data_format_ == DataFormat::NONE) {
-    // time out (default 5.0s)
-    // Measures for data formats that are neither Binary nor ASCII
     auto end_time = std::chrono::system_clock::now();
     double time_elapsed = (double)std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
     if (time_elapsed > timeout) {

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -35,6 +35,7 @@
 #include <utility>
 #include <vector>
 #include <chrono>
+#include <thread>
 
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
 
@@ -287,7 +288,12 @@ void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
 {
   auto start_time = std::chrono::system_clock::now();
   while (data_format_ == DataFormat::NONE) {
-    // time out
+    // sleep (10ms)
+    // Prevent read failures due to high speed loop processing
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    // time out (default 5.0s)
+    // Measures for data formats that are neither Binary nor ASCII
     auto end_time = std::chrono::system_clock::now();
     double time_elapsed = (double)std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
     if (time_elapsed > timeout) {

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -285,16 +285,16 @@ void RtUsb9axisimuRosDriver::stopCommunication(void)
 
 void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
 {
-  auto start_time = std::chrono::system_clock::now();
+  const auto start_time = std::chrono::system_clock::now();
   while (data_format_ == DataFormat::NONE) {
-    auto end_time = std::chrono::system_clock::now();
-    double time_elapsed = (double)std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
+    const auto end_time = std::chrono::system_clock::now();
+    const double time_elapsed = (double)std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
     if (time_elapsed > timeout) {
       return;
     }
     
     unsigned char read_buffer[256];
-    int read_size = serial_port_->readFromDevice(read_buffer, sizeof(read_buffer));
+    const auto read_size = serial_port_->readFromDevice(read_buffer, sizeof(read_buffer));
 
     if(read_size <= 0) {
       continue;

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -85,13 +85,13 @@ RtUsb9axisimuRosDriver::extractBinarySensorData(unsigned char * imu_data_buf)
 bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf, unsigned int data_size)
 {
   for (int i = 0; i < (int)data_size; i++) {
-    bin_read_buffer[bin_read_buffer_idx] = imu_data_buf[i];
-    bin_read_buffer_idx++;
-    if (bin_read_buffer_idx >= 256) bin_read_buffer_idx = 0;
+    bin_read_buffer_[bin_read_buffer_idx_] = imu_data_buf[i];
+    bin_read_buffer_idx_++;
+    if (bin_read_buffer_idx_ >= consts.READ_BUFFER_SIZE) bin_read_buffer_idx_ = 0;
   }
 
   int start_idx = 0;
-  for (int i = 0; i < (int)(bin_read_buffer_idx - consts.IMU_BIN_DATA_SIZE); i++) {
+  for (int i = 0; i < (int)(bin_read_buffer_idx_ - consts.IMU_BIN_DATA_SIZE); i++) {
     if (imu_data_buf[i] == 0xff) {
       start_idx = i;
       break;
@@ -113,7 +113,7 @@ bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf, un
 bool RtUsb9axisimuRosDriver::readBinaryData(void)
 {
   static std::vector<unsigned char> imu_binary_data_buffer;
-  unsigned char read_data_buf[256];
+  unsigned char read_data_buf[consts.READ_BUFFER_SIZE];
 
   has_refreshed_imu_data_ = false;
   int read_data_size = serial_port_->readFromDevice(read_data_buf,
@@ -157,27 +157,27 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
 bool RtUsb9axisimuRosDriver::isAsciiSensorData(unsigned char * imu_data_buf, unsigned int data_size)
 {
   for (int i = 0; i < (int)data_size; i++) {
-    ascii_read_buffer[ascii_read_buffer_idx] = imu_data_buf[i];
-    ascii_read_buffer_idx++;
-    if (ascii_read_buffer_idx >= 256) ascii_read_buffer_idx = 0;
+    ascii_read_buffer_[ascii_read_buffer_idx_] = imu_data_buf[i];
+    ascii_read_buffer_idx_++;
+    if (ascii_read_buffer_idx_ >= consts.READ_BUFFER_SIZE) ascii_read_buffer_idx_ = 0;
   }
 
   // convert imu data to vector in ascii format
   std::vector<std::vector<std::string>> data_vector_ascii;
   std::vector<std::string> data_oneset_ascii;
   std::string data_oneline_ascii;
-  for (int char_count = 0; char_count < (int)ascii_read_buffer_idx; char_count++) {
-    if (ascii_read_buffer[char_count] == '\n') {
+  for (int char_count = 0; char_count < (int)ascii_read_buffer_idx_; char_count++) {
+    if (ascii_read_buffer_[char_count] == '\n') {
       data_oneset_ascii.push_back(data_oneline_ascii);
       data_vector_ascii.push_back(data_oneset_ascii);
       data_oneline_ascii.clear();
       data_oneset_ascii.clear();
     }
-    else if (ascii_read_buffer[char_count] == ',') {
+    else if (ascii_read_buffer_[char_count] == ',') {
       data_oneset_ascii.push_back(data_oneline_ascii);
       data_oneline_ascii.clear();
     } else {
-      data_oneline_ascii += ascii_read_buffer[char_count];
+      data_oneline_ascii += ascii_read_buffer_[char_count];
     }
   }
 
@@ -206,7 +206,7 @@ bool RtUsb9axisimuRosDriver::readAsciiData(void)
 {
   static std::vector<std::string> imu_data_vector_buf;
 
-  unsigned char imu_data_buf[256];
+  unsigned char imu_data_buf[consts.READ_BUFFER_SIZE];
   rt_usb_9axisimu::ImuData<double> imu_data;
   std::string imu_data_oneline_buf;
 
@@ -319,7 +319,7 @@ void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
       return;
     }
     
-    unsigned char read_buffer[256];
+    unsigned char read_buffer[consts.READ_BUFFER_SIZE];
     const auto read_size = serial_port_->readFromDevice(read_buffer, sizeof(read_buffer));
 
     if (read_size <= 0) {

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -31,6 +31,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <iostream>
+
 #include <cstring>
 #include <memory>
 #include <string>
@@ -260,19 +262,59 @@ void RtUsb9axisimuRosDriver::stopCommunication(void)
 void RtUsb9axisimuRosDriver::checkDataFormat(void)
 {
   if (data_format_ == DataFormat::NONE) {
-    unsigned char data_buf[256];
-    int data_size_of_buf = serial_port_->readFromDevice(data_buf, consts.IMU_BIN_DATA_SIZE);
-    if (data_size_of_buf == consts.IMU_BIN_DATA_SIZE) {
-      if (isBinarySensorData(data_buf)) {
+    // read data in binary format
+    unsigned char data_buf_binary[consts.IMU_BIN_DATA_SIZE];
+    int data_size_binary = serial_port_->readFromDevice(data_buf_binary, consts.IMU_BIN_DATA_SIZE);
+
+    // read data in ascii format
+    unsigned char data_buf_ascii[256];
+    int data_size_ascii = serial_port_->readFromDevice(data_buf_ascii, sizeof(data_buf_ascii));
+
+    // convert ascii data to vector
+    static std::vector<std::string> data_vector_ascii;
+    std::string data_oneline_ascii;
+    for (int char_count = 0; char_count < data_size_ascii; char_count++) {
+      if (data_buf_ascii[char_count] == ',' || data_buf_ascii[char_count] == '\n') {
+        data_vector_ascii.push_back(data_oneline_ascii);
+        data_oneline_ascii.clear();
+      } else {
+        data_oneline_ascii += data_buf_ascii[char_count];
+      }
+      if (data_buf_ascii[char_count] == '\n') {
+        break;
+      }
+    }
+
+    // debug
+    std::cout << "--- debug start ---" << std::endl;;
+    for(int i = 0; i < (int)sizeof(data_buf_ascii); i++) {
+      std::cout << data_buf_ascii[i];
+    }
+    std::cout << std::endl;
+    std::cout << data_size_ascii << std::endl;;
+    std::cout << data_vector_ascii.size() << std::endl;;
+    std::cout << "--- debug start ---" << std::endl;;
+
+    // check data format
+    if (data_size_binary == consts.IMU_BIN_DATA_SIZE) {
+      if (isBinarySensorData(data_buf_binary)) {
         data_format_ = DataFormat::BINARY;
         has_completed_format_check_ = true;
       } else {
         data_format_ = DataFormat::NOT_BINARY;
+        has_completed_format_check_ = true;
       }
     }
-  } else if (data_format_ == DataFormat::NOT_BINARY) {
-    data_format_ = DataFormat::ASCII;
-    has_completed_format_check_ = true;
+    if (data_vector_ascii.size() == consts.IMU_ASCII_DATA_SIZE) {
+      if (data_vector_ascii[consts.IMU_ASCII_TIMESTAMP].find(".") == std::string::npos &&
+        isValidAsciiSensorData(data_vector_ascii)) {
+        data_format_ = DataFormat::ASCII;
+        has_completed_format_check_ = true;
+      } else {
+        data_format_ = DataFormat::NOT_ASCII;
+        has_completed_format_check_ = true;
+      }
+    }
   }
 }
 

--- a/src/rt_usb_9axisimu_driver_component.cpp
+++ b/src/rt_usb_9axisimu_driver_component.cpp
@@ -93,21 +93,16 @@ CallbackReturn Driver::on_configure(const rclcpp_lifecycle::State &)
     return CallbackReturn::FAILURE;
   }
 
-  while (rclcpp::ok() && driver_->hasCompletedFormatCheck() == false) {
-    driver_->checkDataFormat();
-  }
+  driver_->checkDataFormat();
 
-  if (rclcpp::ok() && driver_->hasCompletedFormatCheck()) {
-    RCLCPP_INFO(this->get_logger(), "Format check has completed.");
-    if (driver_->hasAsciiDataFormat()) {
-      RCLCPP_INFO(this->get_logger(), "Data format is ascii.");
-    } else if (driver_->hasBinaryDataFormat()) {
-      RCLCPP_INFO(this->get_logger(), "Data format is binary.");
-    } else {
-      RCLCPP_INFO(this->get_logger(), "Data format is neither binary nor ascii.");
-      driver_->stopCommunication();
-      return CallbackReturn::FAILURE;
-    }
+  if (driver_->hasAsciiDataFormat()) {
+    RCLCPP_INFO(this->get_logger(), "Data format is ascii.");
+  } else if (driver_->hasBinaryDataFormat()) {
+    RCLCPP_INFO(this->get_logger(), "Data format is binary.");
+  } else {
+    RCLCPP_INFO(this->get_logger(), "Data format is neither binary nor ascii.");
+    driver_->stopCommunication();
+    return CallbackReturn::FAILURE;
   }
 
   imu_data_raw_pub_ = create_publisher<sensor_msgs::msg::Imu>("imu/data_raw", 1);

--- a/src/rt_usb_9axisimu_driver_component.cpp
+++ b/src/rt_usb_9axisimu_driver_component.cpp
@@ -100,7 +100,7 @@ CallbackReturn Driver::on_configure(const rclcpp_lifecycle::State &)
   } else if (driver_->hasBinaryDataFormat()) {
     RCLCPP_INFO(this->get_logger(), "Data format is binary.");
   } else {
-    RCLCPP_INFO(this->get_logger(), "Data format is neither binary nor ascii.");
+    RCLCPP_WARN(this->get_logger(), "Data format is neither binary nor ascii.");
     driver_->stopCommunication();
     return CallbackReturn::FAILURE;
   }

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -91,8 +91,12 @@ TEST(TestDriver, checkDataFormat_Binary)
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
     unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF0] = 0xff;
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF1] = 0xff;
     dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x52; // R
     dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x54; // T
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID0] = 0x39;
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
     for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
       buf[i] = dummy_bin_imu_data[i];
     }
@@ -118,35 +122,31 @@ TEST(TestDriver, checkDataFormat_ASCII)
   When(Method(mock, readFromDevice)).AlwaysDo([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
-    //std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
-    //dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
-    //ummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
-    //dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
-    //const char split_char = ',';
-    //const char newline_char = 0x0a; // new line
-    //int char_count = 0;
-    //for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
-    //  for(int j = 0; j < (int)strlen(dummy_ascii_imu_data[i]); j++) {
-    //    buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
-    //    char_count++;
-    //  }
-    //  if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
-    //  else buf[char_count] = newline_char;
-    //  char_count++;
-    //}
-    //buf_size = char_count;
-    unsigned char dummy_ascii_imu_data[] =
-      "0,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000\n";
-    buf = dummy_ascii_imu_data;
-    buf_size = (int)strlen((char*)buf);
+    std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
+    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
+    const char split_char = ',';
+    const char newline_char = '\n';
+    int char_count = 0;
+    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
+      for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
+        buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
+        char_count++;
+      }
+      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
+      else buf[char_count] = newline_char;
+      char_count++;
+    }
+    buf_size = char_count;
     return buf_size;
   });
 
@@ -170,7 +170,9 @@ TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
     rt_usb_9axisimu::Consts consts;
     unsigned char dummy_data_not_binary_or_ascii[] =
       "dummy_data_not_binary_or_ascii";
-    buf = dummy_data_not_binary_or_ascii;
+    for(int i = 0; i < (int)sizeof(dummy_data_not_binary_or_ascii); i++) {
+      buf[i] = dummy_data_not_binary_or_ascii[i];
+    }
     buf_size = strlen((char*)buf);
     return buf_size;
   });

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -83,7 +83,24 @@ TEST(TestDriver, checkDataFormat_Binary)
   // Expect to check correctly when read data in binary format
   auto mock = create_serial_port_mock();
 
+  // 1st: invalid binary data ('R' and 'T' positions are reversed)
+  // 2nd: correct binary data ('R' and 'T' are in the correct position)
   When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    rt_usb_9axisimu::Consts consts;
+    unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF0] = 0xff;
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF1] = 0xff;
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x54; // T
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x52; // R
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID0] = 0x39;
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
+    for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
+      buf[i] = dummy_bin_imu_data[i];
+    }
+    buf_size = consts.IMU_BIN_DATA_SIZE;
+    return buf_size;
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
     unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
@@ -114,7 +131,38 @@ TEST(TestDriver, checkDataFormat_ASCII)
   // Expect to check correctly when read data in ASCII format
   auto mock = create_serial_port_mock();
 
+  // 1st: invalid ascii data (timestamp is double)
+  // 2nd: correct ascii data (timestamp is int)
   When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    rt_usb_9axisimu::Consts consts;
+    std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
+    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0.0";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
+    const char split_char = ',';
+    const char newline_char = '\n';
+    int char_count = 0;
+    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
+      for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
+        buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
+        char_count++;
+      }
+      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
+      else buf[char_count] = newline_char;
+      char_count++;
+    }
+    buf_size = char_count;
+    return buf_size;
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
     std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
@@ -159,14 +207,15 @@ TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
   // Expect to check correctly when read data in not Binary or ASCII format
   auto mock = create_serial_port_mock();
 
+  // always invalid data (not binary or ascii)
   When(Method(mock, readFromDevice)).AlwaysDo([](
     unsigned char* buf, unsigned int buf_size) {
     unsigned char dummy_data_not_binary_or_ascii[] =
       "dummy_data_not_binary_or_ascii";
-    buf_size = (unsigned int)strlen((char*)dummy_data_not_binary_or_ascii);
-    for(int i = 0; i < buf_size; i++) {
+    for(int i = 0; i < (int)sizeof(dummy_data_not_binary_or_ascii); i++) {
       buf[i] = dummy_data_not_binary_or_ascii[i];
     }
+    buf_size = strlen((char*)buf);
     return buf_size;
   });
 

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -52,6 +52,59 @@ Mock<SerialPort> create_serial_port_mock(void) {
   return mock;
 }
 
+unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid) {
+  rt_usb_9axisimu::Consts consts;
+  unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
+  dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF0] = 0xff;
+  dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF1] = 0xff;
+  if (is_invalid) {
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x54; // T
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x52; // R
+  } else {
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x52; // R
+    dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x54; // T
+  }
+  dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID0] = 0x39;
+  dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
+  for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
+    buf[i] = dummy_bin_imu_data[i];
+  }
+  return consts.IMU_BIN_DATA_SIZE;
+}
+
+unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid) {
+    rt_usb_9axisimu::Consts consts;
+    std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
+    if (is_invalid) {
+      dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0.0";
+    } else {
+      dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
+    }
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
+    const char split_char = ',';
+    const char newline_char = '\n';
+    unsigned int char_count = 0;
+    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
+      for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
+        buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
+        char_count++;
+      }
+      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
+      else buf[char_count] = newline_char;
+      char_count++;
+    }
+    return char_count;
+}
+
 TEST(TestDriver, startCommunication)
 {
   // Expect the startCommunication method to be called twice and return true then false
@@ -87,33 +140,11 @@ TEST(TestDriver, checkDataFormat_Binary)
   // 2nd: correct binary data ('R' and 'T' are in the correct position)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    rt_usb_9axisimu::Consts consts;
-    unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF0] = 0xff;
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF1] = 0xff;
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x54; // T
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x52; // R
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID0] = 0x39;
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
-    for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
-      buf[i] = dummy_bin_imu_data[i];
-    }
-    buf_size = consts.IMU_BIN_DATA_SIZE;
+    buf_size = create_dummy_bin_imu_data(buf, true);
     return buf_size;
   }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    rt_usb_9axisimu::Consts consts;
-    unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF0] = 0xff;
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF1] = 0xff;
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_R] = 0x52; // R
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_T] = 0x54; // T
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID0] = 0x39;
-    dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
-    for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
-      buf[i] = dummy_bin_imu_data[i];
-    }
-    buf_size = consts.IMU_BIN_DATA_SIZE;
+    buf_size = create_dummy_bin_imu_data(buf, false);
     return buf_size;
   });
 
@@ -135,61 +166,11 @@ TEST(TestDriver, checkDataFormat_ASCII)
   // 2nd: correct ascii data (timestamp is int)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    rt_usb_9axisimu::Consts consts;
-    std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
-    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0.0";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
-    const char split_char = ',';
-    const char newline_char = '\n';
-    int char_count = 0;
-    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
-      for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
-        buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
-        char_count++;
-      }
-      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
-      else buf[char_count] = newline_char;
-      char_count++;
-    }
-    buf_size = char_count;
+    buf_size = create_dummy_ascii_imu_data(buf, true);
     return buf_size;
   }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    rt_usb_9axisimu::Consts consts;
-    std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
-    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
-    const char split_char = ',';
-    const char newline_char = '\n';
-    int char_count = 0;
-    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
-      for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
-        buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
-        char_count++;
-      }
-      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
-      else buf[char_count] = newline_char;
-      char_count++;
-    }
-    buf_size = char_count;
+    buf_size = create_dummy_ascii_imu_data(buf, false);
     return buf_size;
   });
 

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -31,10 +31,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <array>
 #include <vector>
-#include <string>
-#include <iostream>
 #include <gtest/gtest.h>
 #include "fakeit.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
@@ -76,7 +73,6 @@ TEST(TestDriver, initialize_member_variables)
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  EXPECT_FALSE(driver.hasCompletedFormatCheck());
   EXPECT_FALSE(driver.hasBinaryDataFormat());
   EXPECT_FALSE(driver.hasAsciiDataFormat());
   EXPECT_FALSE(driver.hasRefreshedImuData());
@@ -87,7 +83,7 @@ TEST(TestDriver, checkDataFormat_Binary)
   // Expect to check correctly when read data in binary format
   auto mock = create_serial_port_mock();
 
-  When(Method(mock, readFromDevice)).AlwaysDo([](
+  When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
     unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
@@ -109,7 +105,6 @@ TEST(TestDriver, checkDataFormat_Binary)
 
   driver.checkDataFormat();
 
-  EXPECT_TRUE(driver.hasCompletedFormatCheck());
   EXPECT_TRUE(driver.hasBinaryDataFormat());
   EXPECT_FALSE(driver.hasAsciiDataFormat());
 }
@@ -119,7 +114,7 @@ TEST(TestDriver, checkDataFormat_ASCII)
   // Expect to check correctly when read data in ASCII format
   auto mock = create_serial_port_mock();
 
-  When(Method(mock, readFromDevice)).AlwaysDo([](
+  When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
     std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
@@ -155,7 +150,6 @@ TEST(TestDriver, checkDataFormat_ASCII)
 
   driver.checkDataFormat();
 
-  EXPECT_TRUE(driver.hasCompletedFormatCheck());
   EXPECT_TRUE(driver.hasAsciiDataFormat());
   EXPECT_FALSE(driver.hasBinaryDataFormat());
 }
@@ -167,13 +161,12 @@ TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
 
   When(Method(mock, readFromDevice)).AlwaysDo([](
     unsigned char* buf, unsigned int buf_size) {
-    rt_usb_9axisimu::Consts consts;
     unsigned char dummy_data_not_binary_or_ascii[] =
       "dummy_data_not_binary_or_ascii";
-    for(int i = 0; i < (int)sizeof(dummy_data_not_binary_or_ascii); i++) {
+    buf_size = (unsigned int)strlen((char*)dummy_data_not_binary_or_ascii);
+    for(int i = 0; i < buf_size; i++) {
       buf[i] = dummy_data_not_binary_or_ascii[i];
     }
-    buf_size = strlen((char*)buf);
     return buf_size;
   });
 
@@ -182,7 +175,6 @@ TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
 
   driver.checkDataFormat();
 
-  EXPECT_FALSE(driver.hasCompletedFormatCheck());
   EXPECT_FALSE(driver.hasBinaryDataFormat());
   EXPECT_FALSE(driver.hasAsciiDataFormat());
 }

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -32,7 +32,9 @@
  */
 
 #include <array>
+#include <vector>
 #include <string>
+#include <iostream>
 #include <gtest/gtest.h>
 #include "fakeit.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
@@ -85,7 +87,7 @@ TEST(TestDriver, checkDataFormat_Binary)
   // Expect to check correctly when read data in binary format
   auto mock = create_serial_port_mock();
 
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).AlwaysDo([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
     unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
@@ -113,38 +115,44 @@ TEST(TestDriver, checkDataFormat_ASCII)
   // Expect to check correctly when read data in ASCII format
   auto mock = create_serial_port_mock();
 
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).AlwaysDo([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
-    std::array<std::string, consts.IMU_ASCII_DATA_SIZE> dummy_ascii_imu_data; 
-    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
-    std::string str = "";
-    std::string split_char = ",";
-    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
-      str += dummy_ascii_imu_data[i];
-      if(i != consts.IMU_ASCII_DATA_SIZE - 1) str += split_char;
-    }
-    for(int i = 0; i < int(str.length()); i++) {
-      buf[i] = str[i];
-    }
-    buf_size = consts.IMU_BIN_DATA_SIZE;
+    //std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
+    //dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
+    //ummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
+    //dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
+    //const char split_char = ',';
+    //const char newline_char = 0x0a; // new line
+    //int char_count = 0;
+    //for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
+    //  for(int j = 0; j < (int)strlen(dummy_ascii_imu_data[i]); j++) {
+    //    buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
+    //    char_count++;
+    //  }
+    //  if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
+    //  else buf[char_count] = newline_char;
+    //  char_count++;
+    //}
+    //buf_size = char_count;
+    unsigned char dummy_ascii_imu_data[] =
+      "0,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000,0.000000\n";
+    buf = dummy_ascii_imu_data;
+    buf_size = (int)strlen((char*)buf);
     return buf_size;
   });
 
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  driver.checkDataFormat();
   driver.checkDataFormat();
 
   EXPECT_TRUE(driver.hasCompletedFormatCheck());
@@ -157,15 +165,13 @@ TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
   // Expect to check correctly when read data in not Binary or ASCII format
   auto mock = create_serial_port_mock();
 
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).AlwaysDo([](
     unsigned char* buf, unsigned int buf_size) {
     rt_usb_9axisimu::Consts consts;
     unsigned char dummy_data_not_binary_or_ascii[] =
       "dummy_data_not_binary_or_ascii";
-    for(int i = 0; i < int(sizeof(dummy_data_not_binary_or_ascii)); i++) {
-      buf[i] = dummy_data_not_binary_or_ascii[i];
-    }
-    buf_size = consts.IMU_BIN_DATA_SIZE;
+    buf = dummy_data_not_binary_or_ascii;
+    buf_size = strlen((char*)buf);
     return buf_size;
   });
 

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -92,14 +92,15 @@ unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid) {
     dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
     const char split_char = ',';
     const char newline_char = '\n';
-    unsigned int char_count = 0;
+    buf[0] = (unsigned char)newline_char;
+    unsigned int char_count = 1;
     for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
       for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
         buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
         char_count++;
       }
-      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = split_char;
-      else buf[char_count] = newline_char;
+      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = (unsigned char)split_char;
+      else buf[char_count] = (unsigned char)newline_char;
       char_count++;
     }
     return char_count;


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
checkDataFormat関数を下記のように更新しました。

- ASCII形式のチェック機能を追加
- BinaryでもASCIIでもない形式のチェックも追加
- while文を追加&タイムアウト機能を追加

それ以外にも下記を修正しました。

- Binary形式のチェックを強化
- 不正なデータを読み込んでから正常なデータを読み込むように単体テストを修正
- 必要がなくなったのでhasCompletedFormatCheck()を削除

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
下記のissueに対応します。
- https://github.com/rt-net/rt_usb_9axisimu_driver/issues/53
- https://github.com/rt-net/rt_usb_9axisimu_driver/issues/55

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
実機とテストの両方で動作確認をしました。

# Any other comments?
<!-- その他コメントはありますか？ -->
- https://github.com/rt-net/rt_usb_9axisimu_driver/pull/52#discussion_r1553070415 でヘルパー関数を作成する話がありましたが、実装に時間がかかりそうなので今回は見送りました。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
