### PR TITLE
Add test for readSensorData()

### DIFF
--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -104,14 +104,6 @@ public:
   std::unique_ptr<sensor_msgs::msg::MagneticField> getImuMagUniquePtr(const rclcpp::Time timestamp);
   std::unique_ptr<std_msgs::msg::Float64> getImuTemperatureUniquePtr(void);
   bool readSensorData();
-
-  void setBinaryFormat() {
-    data_format_ = DataFormat::BINARY;
-  }
-
-  void setAsciiFormat() {
-    data_format_ = DataFormat::ASCII;
-  }
 };
 
 #endif  // RT_USB_9AXISIMU_DRIVER__RT_USB_9AXISIMU_DRIVER_HPP_

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -104,6 +104,14 @@ public:
   std::unique_ptr<sensor_msgs::msg::MagneticField> getImuMagUniquePtr(const rclcpp::Time timestamp);
   std::unique_ptr<std_msgs::msg::Float64> getImuTemperatureUniquePtr(void);
   bool readSensorData();
+
+  void setBinaryFormat() {
+    data_format_ = DataFormat::BINARY;
+  }
+
+  void setAsciiFormat() {
+    data_format_ = DataFormat::ASCII;
+  }
 };
 
 #endif  // RT_USB_9AXISIMU_DRIVER__RT_USB_9AXISIMU_DRIVER_HPP_

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -57,21 +57,22 @@ public:
   double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
 
   ReadBinaryTestParam (int case_num) {
-    if (case_num == 0) set_data(0); // zero
-    else if (case_num == 1) set_data(32767); // max
-    else if (case_num == 2) set_data(-32768); // min
-    else if (case_num == 3) set_data(32766); // boundary
-    else if (case_num == 4) set_data(-32767); // boundary
-    else if (case_num == 5) set_data(1); // random
-    else if (case_num == 6) set_data(-1); // random
-    else if (case_num == 7) set_data(999); // random
-    else if (case_num == 8) set_data(-999); // random
-    else if (case_num == 9) set_data(12345); // random
-    else if (case_num == 10) set_data(-12345); // random
+    if (case_num == 0) set_data(0, 0.0, 0.0, 0.0, 21.0); // zero
+    else if (case_num == 1) set_data(32767, 34.87147, 156.90161, 0.00492, 119.14299); // max
+    else if (case_num == 2) set_data(-32768, -34.87253, -156.9064, -0.00492, -77.14598); // min
+    else if (case_num == 3) set_data(32766, 34.870401, 156.896823, 0.004915, 119.139995); // boundary
+    else if (case_num == 4) set_data(-32767, -34.871466, -156.901612, -0.004915, -77.14299); // boundary
+    else if (case_num == 5) set_data(1, 0.001064, 0.004788, 0.0, 21.002995); // random
+    else if (case_num == 6) set_data(-1, -0.001064, -0.004788, 0.0, 20.997005); // random
+    else if (case_num == 7) set_data(999, 1.063161, 4.783615, 0.00015, 23.992183); // random
+    else if (case_num == 8) set_data(-999, -1.063161, -4.783615, -0.00015, 18.007817); // random
+    else if (case_num == 9) set_data(12345, 13.13786, 59.112839, 0.001852, 57.975469); // random
+    else if (case_num == 10) set_data(-12345, -13.13786, -59.112839, -0.001852, -15.975469); // random
   }
 
 private:
-  void set_data (int16_t test_val) {
+  void set_data (int16_t test_val,
+                 double ans_gyro_val, double ans_acc_val, double ans_mag_val, double ans_temp_val) {
     rt_usb_9axisimu::Consts consts;
     const int test_firmfare_ver = 18;
     consts.ChangeConvertor(test_firmfare_ver);
@@ -79,10 +80,10 @@ private:
     acc[0] = acc[1] = acc[2] = test_val;
     mag[0] = mag[1] = mag[2] = test_val;
     temp = test_val;
-    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = (double)(test_val / consts.CONVERTOR_RAW2DPS * consts.CONVERTOR_D2R);
-    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(test_val / consts.CONVERTOR_RAW2G * consts.CONVERTOR_G2A);
-    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(test_val * consts.CONVERTOR_RAW2UT / consts.CONVERTOR_UT2T);
-    ans_temp = (double)(test_val / consts.CONVERTOR_RAW2C_1 + consts.CONVERTOR_RAW2C_2);
+    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = ans_gyro_val;
+    ans_acc[0] = ans_acc[1] = ans_acc[2] = ans_acc_val;
+    ans_mag[0] = ans_mag[1] = ans_mag[2] = ans_mag_val;
+    ans_temp = ans_temp_val;
   }
 };
 
@@ -92,21 +93,22 @@ public:
   double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
 
   ReadAsciiTestParam (int case_num) {
-    if(case_num == 0) set_data(0.0, 0.0, 0.0, 0.0); // zero
-    else if(case_num == 1) set_data(34.906585, 16.0, 4800.0, 85.0); // max
-    else if(case_num == 2) set_data(-34.906585, -16.0, -4800.0, -40.0); // min
-    else if(case_num == 3) set_data(0.00107, 0.0005, 0.14649, 0.0026); // resolution
-    else if(case_num == 4) set_data(-0.00107, -0.0005, -0.14649, -0.00122); // resolution
-    else if(case_num == 5) set_data(0.1, 0.1, 0.1, 0.1); // random
-    else if(case_num == 6) set_data(-0.1, -0.1, -0.1, -0.1); // random
-    else if(case_num == 7) set_data(1.0, 1.0, 1.0, 1.0); // random
-    else if(case_num == 8) set_data(-1.0, -1.0, -1.0, -1.0); // random
-    else if(case_num == 9) set_data(12.34567, 12.34567, 12.34567, 12.34567); // random
-    else if(case_num == 10) set_data(-12.34567, -12.34567, -12.34567, -12.34567); // random
+    if(case_num == 0) set_data(0.0, 0.0, 0.0, 0.0, 0.0, 0.0); // zero
+    else if(case_num == 1) set_data(34.906585, 16.0, 4800.0, 85.0, 156.9064, 0.0048); // max
+    else if(case_num == 2) set_data(-34.906585, -16.0, -4800.0, -40.0, -156.9064, -0.0048); // min
+    else if(case_num == 3) set_data(0.00107, 0.0005, 0.14649, 0.0026, 0.00479, 0.00000015); // resolution
+    else if(case_num == 4) set_data(-0.00107, -0.0005, -0.14649, -0.00122, -0.00479, -0.00000015); // resolution
+    else if(case_num == 5) set_data(0.1, 0.1, 0.1, 0.1, 0.98067, 0.0000001); // random
+    else if(case_num == 6) set_data(-0.1, -0.1, -0.1, -0.1, -0.98067, 0.0000001); // random
+    else if(case_num == 7) set_data(1.0, 1.0, 1.0, 1.0, 9.80665, 0.000001); // random
+    else if(case_num == 8) set_data(-1.0, -1.0, -1.0, -1.0, -9.80665, -0.000001); // random
+    else if(case_num == 9) set_data(12.34567, 12.34567, 12.34567, 12.34567, 121.06966, 0.00001); // random
+    else if(case_num == 10) set_data(-12.34567, -12.34567, -12.34567, -12.34567, -121.06966, -0.00001); // random
   }
 
 private:
-  void set_data (double gyro_val, double acc_val, double mag_val, double temp_val) {
+  void set_data (double gyro_val, double acc_val, double mag_val, double temp_val,
+                 double ans_acc_val, double ans_mag_val) {
     rt_usb_9axisimu::Consts consts;
     const int test_firmfare_ver = 18;
     consts.ChangeConvertor(test_firmfare_ver);
@@ -115,8 +117,8 @@ private:
     mag[0] = mag[1] = mag[2] = mag_val;
     temp = temp_val;
     ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = gyro_val;
-    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(acc_val * consts.CONVERTOR_G2A);
-    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(mag_val / consts.CONVERTOR_UT2T);
+    ans_acc[0] = ans_acc[1] = ans_acc[2] = ans_acc_val;
+    ans_mag[0] = ans_mag[1] = ans_mag[2] = ans_mag_val;
     ans_temp = temp_val;
   }
 };
@@ -425,7 +427,7 @@ TEST_P(ReadBinaryTest, read_binary_test) {
 
   const double abs_error_acc = 1e-3;
   const double abs_error_gyro = 1e-3;
-  const double abs_error_mag = 1e-7;
+  const double abs_error_mag = 1e-5;
   const double abs_error_temp = 1e-3;
   EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error_acc);
   EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error_acc);
@@ -484,7 +486,7 @@ TEST_P(ReadAsciiTest, read_ascii_test) {
 
   const double abs_error_acc = 1e-3;
   const double abs_error_gyro = 1e-3;
-  const double abs_error_mag = 1e-7;
+  const double abs_error_mag = 1e-5;
   const double abs_error_temp = 1e-3;
   EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error_acc);
   EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error_acc);

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -120,9 +120,12 @@ Mock<SerialPort> create_serial_port_mock(void) {
   return mock;
 }
 
-unsigned char int16_to_byte(int16_t val, bool is_low) {
-  if (is_low) return (val >> 0) & 0xFF;
-  else return (val >> 8) & 0xFF;
+unsigned char int16_to_byte_low_8bit(int16_t val) {
+  return (val >> 0) & 0xFF;
+}
+
+unsigned char int16_to_byte_high_8bit(int16_t val) {
+  return (val >> 8) & 0xFF;
 }
 
 unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
@@ -142,26 +145,26 @@ unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
   dummy_bin_imu_data[consts.IMU_BIN_FIRMWARE] = 0x12;
   dummy_bin_imu_data[consts.IMU_BIN_TIMESTAMP] = 0x00;
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_L] = int16_to_byte(acc[0], true);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_H] = int16_to_byte(acc[0], false);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_L] = int16_to_byte(acc[1], true);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_H] = int16_to_byte(acc[1], false);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_L] = int16_to_byte(acc[2], true);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_H] = int16_to_byte(acc[2], false);
-  dummy_bin_imu_data[consts.IMU_BIN_TEMP_L] = int16_to_byte(temp, true);
-  dummy_bin_imu_data[consts.IMU_BIN_TEMP_H] = int16_to_byte(temp, false);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_L] = int16_to_byte(gyro[0], true);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_H] = int16_to_byte(gyro[0], false);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_L] = int16_to_byte(gyro[1], true);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_H] = int16_to_byte(gyro[1], false);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_L] = int16_to_byte(gyro[2], true);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_H] = int16_to_byte(gyro[2], false);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_L] = int16_to_byte(mag[0], true);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_H] = int16_to_byte(mag[0], false);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_L] = int16_to_byte(mag[1], true);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_H] = int16_to_byte(mag[1], false);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_L] = int16_to_byte(mag[2], true);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_H] = int16_to_byte(mag[2], false);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_L] = int16_to_byte_low_8bit(acc[0]);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_H] = int16_to_byte_high_8bit(acc[0]);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_L] = int16_to_byte_low_8bit(acc[1]);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_H] = int16_to_byte_high_8bit(acc[1]);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_L] = int16_to_byte_low_8bit(acc[2]);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_H] = int16_to_byte_high_8bit(acc[2]);
+  dummy_bin_imu_data[consts.IMU_BIN_TEMP_L] = int16_to_byte_low_8bit(temp);
+  dummy_bin_imu_data[consts.IMU_BIN_TEMP_H] = int16_to_byte_high_8bit(temp);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_L] = int16_to_byte_low_8bit(gyro[0]);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_H] = int16_to_byte_high_8bit(gyro[0]);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_L] = int16_to_byte_low_8bit(gyro[1]);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_H] = int16_to_byte_high_8bit(gyro[1]);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_L] = int16_to_byte_low_8bit(gyro[2]);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_H] = int16_to_byte_high_8bit(gyro[2]);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_L] = int16_to_byte_low_8bit(mag[0]);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_H] = int16_to_byte_high_8bit(mag[0]);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_L] = int16_to_byte_low_8bit(mag[1]);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_H] = int16_to_byte_high_8bit(mag[1]);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_L] = int16_to_byte_low_8bit(mag[2]);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_H] = int16_to_byte_high_8bit(mag[2]);
   for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
     buf[i] = dummy_bin_imu_data[i];
   }

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -56,20 +56,6 @@ public:
   int16_t gyro[3], acc[3], mag[3], temp;
   double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
 
-  void set_data (int16_t test_val) {
-    rt_usb_9axisimu::Consts consts;
-    const int test_firmfare_ver = 18;
-    consts.ChangeConvertor(test_firmfare_ver);
-    gyro[0] = gyro[1] = gyro[2] = test_val;
-    acc[0] = acc[1] = acc[2] = test_val;
-    mag[0] = mag[1] = mag[2] = test_val;
-    temp = test_val;
-    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = (double)(test_val / consts.CONVERTOR_RAW2DPS * consts.CONVERTOR_D2R);
-    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(test_val / consts.CONVERTOR_RAW2G * consts.CONVERTOR_G2A);
-    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(test_val * consts.CONVERTOR_RAW2UT / consts.CONVERTOR_UT2T);
-    ans_temp = (double)(test_val / consts.CONVERTOR_RAW2C_1 + consts.CONVERTOR_RAW2C_2);
-  }
-
   ReadBinaryTestParam (int case_num) {
     if (case_num == 0) set_data(0); // zero
     else if (case_num == 1) set_data(32767); // max
@@ -83,26 +69,27 @@ public:
     else if (case_num == 9) set_data(12345); // random
     else if (case_num == 10) set_data(-12345); // random
   }
+
+private:
+  void set_data (int16_t test_val) {
+    rt_usb_9axisimu::Consts consts;
+    const int test_firmfare_ver = 18;
+    consts.ChangeConvertor(test_firmfare_ver);
+    gyro[0] = gyro[1] = gyro[2] = test_val;
+    acc[0] = acc[1] = acc[2] = test_val;
+    mag[0] = mag[1] = mag[2] = test_val;
+    temp = test_val;
+    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = (double)(test_val / consts.CONVERTOR_RAW2DPS * consts.CONVERTOR_D2R);
+    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(test_val / consts.CONVERTOR_RAW2G * consts.CONVERTOR_G2A);
+    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(test_val * consts.CONVERTOR_RAW2UT / consts.CONVERTOR_UT2T);
+    ans_temp = (double)(test_val / consts.CONVERTOR_RAW2C_1 + consts.CONVERTOR_RAW2C_2);
+  }
 };
 
 class ReadAsciiTestParam {
 public:
   double gyro[3], acc[3], mag[3], temp;
   double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
-
-  void set_data (double gyro_val, double acc_val, double mag_val, double temp_val) {
-    rt_usb_9axisimu::Consts consts;
-    const int test_firmfare_ver = 18;
-    consts.ChangeConvertor(test_firmfare_ver);
-    gyro[0] = gyro[1] = gyro[2] = gyro_val;
-    acc[0] = acc[1] = acc[2] = acc_val;
-    mag[0] = mag[1] = mag[2] = mag_val;
-    temp = temp_val;
-    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = gyro_val;
-    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(acc_val * consts.CONVERTOR_G2A);
-    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(mag_val / consts.CONVERTOR_UT2T);
-    ans_temp = temp_val;
-  }
 
   ReadAsciiTestParam (int case_num) {
     if(case_num == 0) set_data(0.0, 0.0, 0.0, 0.0); // zero
@@ -116,6 +103,21 @@ public:
     else if(case_num == 8) set_data(-1.0, -1.0, -1.0, -1.0); // random
     else if(case_num == 9) set_data(12.34567, 12.34567, 12.34567, 12.34567); // random
     else if(case_num == 10) set_data(-12.34567, -12.34567, -12.34567, -12.34567); // random
+  }
+
+private:
+  void set_data (double gyro_val, double acc_val, double mag_val, double temp_val) {
+    rt_usb_9axisimu::Consts consts;
+    const int test_firmfare_ver = 18;
+    consts.ChangeConvertor(test_firmfare_ver);
+    gyro[0] = gyro[1] = gyro[2] = gyro_val;
+    acc[0] = acc[1] = acc[2] = acc_val;
+    mag[0] = mag[1] = mag[2] = mag_val;
+    temp = temp_val;
+    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = gyro_val;
+    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(acc_val * consts.CONVERTOR_G2A);
+    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(mag_val / consts.CONVERTOR_UT2T);
+    ans_temp = temp_val;
   }
 };
 

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -212,8 +212,11 @@ TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
 
 TEST(TestDriver, readSensorData_Binary)
 {
+  // Expect to check the data is correctly updated when binary data is read
   auto mock = create_serial_port_mock();
 
+  // 1st: invalid binary data ('R' and 'T' positions are reversed)
+  // 2nd: correct binary data ('R' and 'T' are in the correct position)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
     buf_size = create_dummy_bin_imu_data(buf, true);
@@ -239,8 +242,11 @@ TEST(TestDriver, readSensorData_Binary)
 
 TEST(TestDriver, readSensorData_ASCII)
 {
+  // Expect to check the data is correctly updated when ascii data is read
   auto mock = create_serial_port_mock();
 
+  // 1st: invalid ascii data (timestamp is double)
+  // 2nd: correct ascii data (timestamp is int)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
     buf_size = create_dummy_ascii_imu_data(buf, true);

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -452,17 +452,6 @@ INSTANTIATE_TEST_SUITE_P(
 class ReadAsciiTest : public testing::TestWithParam<ReadAsciiTestParam> {
 };
 
-int16_t comb(unsigned char data_h, unsigned char data_l)
-{
-  int16_t short_data = 0;
-
-  short_data = data_h;
-  short_data = short_data << 8;
-  short_data |= data_l;
-
-  return short_data;
-}
-
 TEST_P(ReadAsciiTest, read_ascii_test) {
   // Expect to check the data is correctly converted when ascii data is read
   auto mock = create_serial_port_mock();

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -43,16 +43,10 @@ using rt_usb_9axisimu::SerialPort;
 
 class ReadBinaryTestParam {
 public:
-  short int gyro[3];
-  short int acc[3];
-  short int mag[3];
-  short int temp;
-  double ans_gyro[3];
-  double ans_acc[3];
-  double ans_mag[3];
-  double ans_temp;
+  int16_t gyro[3], acc[3], mag[3], temp;
+  double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
 
-  void set_data (short int test_val) {
+  void set_data (int16_t test_val) {
       rt_usb_9axisimu::Consts consts;
       const int test_firmfare_ver = 18;
       consts.ChangeConvertor(test_firmfare_ver);
@@ -83,14 +77,8 @@ public:
 
 class ReadAsciiTestParam {
 public:
-  double gyro[3];
-  double acc[3];
-  double mag[3];
-  double temp;
-  double ans_gyro[3];
-  double ans_acc[3];
-  double ans_mag[3];
-  double ans_temp;
+  double gyro[3], acc[3], mag[3], temp;
+  double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
 
   void set_data (double gyro_val, double acc_val, double mag_val, double temp_val) {
       rt_usb_9axisimu::Consts consts;
@@ -132,14 +120,13 @@ Mock<SerialPort> create_serial_port_mock(void) {
   return mock;
 }
 
-// Expect that short int is 2 bytes.
-unsigned char short_int_to_byte(short int val, bool is_low) {
+unsigned char int16_to_byte(int16_t val, bool is_low) {
   if (is_low) return (val >> 0) & 0xFF;
   else return (val >> 8) & 0xFF;
 }
 
 unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
-                                       short int *gyro, short int *acc, short int *mag, short int temp) {
+                                       int16_t *gyro, int16_t *acc, int16_t *mag, int16_t temp) {
   rt_usb_9axisimu::Consts consts;
   unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF0] = 0xff;
@@ -155,26 +142,26 @@ unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
   dummy_bin_imu_data[consts.IMU_BIN_FIRMWARE] = 0x12;
   dummy_bin_imu_data[consts.IMU_BIN_TIMESTAMP] = 0x00;
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_L] = short_int_to_byte(acc[0], true);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_H] = short_int_to_byte(acc[0], false);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_L] = short_int_to_byte(acc[1], true);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_H] = short_int_to_byte(acc[1], false);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_L] = short_int_to_byte(acc[2], true);
-  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_H] = short_int_to_byte(acc[2], false);
-  dummy_bin_imu_data[consts.IMU_BIN_TEMP_L] = short_int_to_byte(temp, true);
-  dummy_bin_imu_data[consts.IMU_BIN_TEMP_H] = short_int_to_byte(temp, false);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_L] = short_int_to_byte(gyro[0], true);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_H] = short_int_to_byte(gyro[0], false);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_L] = short_int_to_byte(gyro[1], true);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_H] = short_int_to_byte(gyro[1], false);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_L] = short_int_to_byte(gyro[2], true);
-  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_H] = short_int_to_byte(gyro[2], false);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_L] = short_int_to_byte(mag[0], true);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_H] = short_int_to_byte(mag[0], false);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_L] = short_int_to_byte(mag[1], true);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_H] = short_int_to_byte(mag[1], false);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_L] = short_int_to_byte(mag[2], true);
-  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_H] = short_int_to_byte(mag[2], false);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_L] = int16_to_byte(acc[0], true);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_H] = int16_to_byte(acc[0], false);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_L] = int16_to_byte(acc[1], true);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_H] = int16_to_byte(acc[1], false);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_L] = int16_to_byte(acc[2], true);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_H] = int16_to_byte(acc[2], false);
+  dummy_bin_imu_data[consts.IMU_BIN_TEMP_L] = int16_to_byte(temp, true);
+  dummy_bin_imu_data[consts.IMU_BIN_TEMP_H] = int16_to_byte(temp, false);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_L] = int16_to_byte(gyro[0], true);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_H] = int16_to_byte(gyro[0], false);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_L] = int16_to_byte(gyro[1], true);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_H] = int16_to_byte(gyro[1], false);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_L] = int16_to_byte(gyro[2], true);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_H] = int16_to_byte(gyro[2], false);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_L] = int16_to_byte(mag[0], true);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_H] = int16_to_byte(mag[0], false);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_L] = int16_to_byte(mag[1], true);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_H] = int16_to_byte(mag[1], false);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_L] = int16_to_byte(mag[2], true);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_H] = int16_to_byte(mag[2], false);
   for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
     buf[i] = dummy_bin_imu_data[i];
   }

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -73,9 +73,6 @@ public:
 private:
   void set_data (int16_t test_val,
                  double ans_gyro_val, double ans_acc_val, double ans_mag_val, double ans_temp_val) {
-    rt_usb_9axisimu::Consts consts;
-    const int test_firmfare_ver = 18;
-    consts.ChangeConvertor(test_firmfare_ver);
     gyro[0] = gyro[1] = gyro[2] = test_val;
     acc[0] = acc[1] = acc[2] = test_val;
     mag[0] = mag[1] = mag[2] = test_val;
@@ -109,9 +106,6 @@ public:
 private:
   void set_data (double gyro_val, double acc_val, double mag_val, double temp_val,
                  double ans_acc_val, double ans_mag_val) {
-    rt_usb_9axisimu::Consts consts;
-    const int test_firmfare_ver = 18;
-    consts.ChangeConvertor(test_firmfare_ver);
     gyro[0] = gyro[1] = gyro[2] = gyro_val;
     acc[0] = acc[1] = acc[2] = acc_val;
     mag[0] = mag[1] = mag[2] = mag_val;

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -41,23 +41,33 @@ using fakeit::Mock;
 using fakeit::When;
 using rt_usb_9axisimu::SerialPort;
 
+unsigned char int16_to_byte_low_8bit(int16_t val);
+unsigned char int16_to_byte_high_8bit(int16_t val);
+unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid);
+unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
+                                       int16_t *gyro, int16_t *acc, int16_t *mag, int16_t temp);
+std::string double_to_string(double val);
+unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid);
+unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid,
+                                         double *gyro, double *acc, double *mag, double temp);
+
 class ReadBinaryTestParam {
 public:
   int16_t gyro[3], acc[3], mag[3], temp;
   double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
 
   void set_data (int16_t test_val) {
-      rt_usb_9axisimu::Consts consts;
-      const int test_firmfare_ver = 18;
-      consts.ChangeConvertor(test_firmfare_ver);
-      gyro[0] = gyro[1] = gyro[2] = test_val;
-      acc[0] = acc[1] = acc[2] = test_val;
-      mag[0] = mag[1] = mag[2] = test_val;
-      temp = test_val;
-      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = (double)(test_val / consts.CONVERTOR_RAW2DPS * consts.CONVERTOR_D2R);
-      ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(test_val / consts.CONVERTOR_RAW2G * consts.CONVERTOR_G2A);
-      ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(test_val * consts.CONVERTOR_RAW2UT / consts.CONVERTOR_UT2T);
-      ans_temp = (double)(test_val / consts.CONVERTOR_RAW2C_1 + consts.CONVERTOR_RAW2C_2);
+    rt_usb_9axisimu::Consts consts;
+    const int test_firmfare_ver = 18;
+    consts.ChangeConvertor(test_firmfare_ver);
+    gyro[0] = gyro[1] = gyro[2] = test_val;
+    acc[0] = acc[1] = acc[2] = test_val;
+    mag[0] = mag[1] = mag[2] = test_val;
+    temp = test_val;
+    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = (double)(test_val / consts.CONVERTOR_RAW2DPS * consts.CONVERTOR_D2R);
+    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(test_val / consts.CONVERTOR_RAW2G * consts.CONVERTOR_G2A);
+    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(test_val * consts.CONVERTOR_RAW2UT / consts.CONVERTOR_UT2T);
+    ans_temp = (double)(test_val / consts.CONVERTOR_RAW2C_1 + consts.CONVERTOR_RAW2C_2);
   }
 
   ReadBinaryTestParam (int case_num) {
@@ -81,17 +91,17 @@ public:
   double ans_gyro[3], ans_acc[3], ans_mag[3], ans_temp;
 
   void set_data (double gyro_val, double acc_val, double mag_val, double temp_val) {
-      rt_usb_9axisimu::Consts consts;
-      const int test_firmfare_ver = 18;
-      consts.ChangeConvertor(test_firmfare_ver);
-      gyro[0] = gyro[1] = gyro[2] = gyro_val;
-      acc[0] = acc[1] = acc[2] = acc_val;
-      mag[0] = mag[1] = mag[2] = mag_val;
-      temp = temp_val;
-      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = gyro_val;
-      ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(acc_val * consts.CONVERTOR_G2A);
-      ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(mag_val / consts.CONVERTOR_UT2T);
-      ans_temp = temp_val;
+    rt_usb_9axisimu::Consts consts;
+    const int test_firmfare_ver = 18;
+    consts.ChangeConvertor(test_firmfare_ver);
+    gyro[0] = gyro[1] = gyro[2] = gyro_val;
+    acc[0] = acc[1] = acc[2] = acc_val;
+    mag[0] = mag[1] = mag[2] = mag_val;
+    temp = temp_val;
+    ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = gyro_val;
+    ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(acc_val * consts.CONVERTOR_G2A);
+    ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(mag_val / consts.CONVERTOR_UT2T);
+    ans_temp = temp_val;
   }
 
   ReadAsciiTestParam (int case_num) {
@@ -126,6 +136,11 @@ unsigned char int16_to_byte_low_8bit(int16_t val) {
 
 unsigned char int16_to_byte_high_8bit(int16_t val) {
   return (val >> 8) & 0xFF;
+}
+
+unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid) {
+  ReadBinaryTestParam data(0);
+  return create_dummy_bin_imu_data(buf, is_invalid, data.gyro, data.acc, data.mag, data.temp);
 }
 
 unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
@@ -172,44 +187,49 @@ unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
 }
 
 std::string double_to_string(double val) {
-    std::string str = std::to_string(val);
-    str.resize(8, '0');
-    return str;
+  std::string str = std::to_string(val);
+  str.resize(8, '0');
+  return str;
+}
+
+unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid) {
+  ReadAsciiTestParam data(0);
+  return create_dummy_ascii_imu_data(buf, is_invalid, data.gyro, data.acc, data.mag, data.temp);
 }
 
 unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid,
                                          double *gyro, double *acc, double *mag, double temp) {
-    rt_usb_9axisimu::Consts consts;
-    std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
-    if (is_invalid) {
-      dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0.0";
-    } else {
-      dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
-    }
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = double_to_string(gyro[0]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = double_to_string(gyro[1]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = double_to_string(gyro[2]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = double_to_string(acc[0]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = double_to_string(acc[1]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = double_to_string(acc[2]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = double_to_string(mag[0]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = double_to_string(mag[1]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = double_to_string(mag[2]).c_str();
-    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = double_to_string(temp).c_str();
-    const char split_char = ',';
-    const char newline_char = '\n';
-    buf[0] = (unsigned char)newline_char;
-    unsigned int char_count = 1;
-    for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
-      for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
-        buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
-        char_count++;
-      }
-      if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = (unsigned char)split_char;
-      else buf[char_count] = (unsigned char)newline_char;
+  rt_usb_9axisimu::Consts consts;
+  std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
+  if (is_invalid) {
+    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0.0";
+  } else {
+    dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
+  }
+  dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = double_to_string(gyro[0]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = double_to_string(gyro[1]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = double_to_string(gyro[2]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = double_to_string(acc[0]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = double_to_string(acc[1]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = double_to_string(acc[2]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = double_to_string(mag[0]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = double_to_string(mag[1]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = double_to_string(mag[2]).c_str();
+  dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = double_to_string(temp).c_str();
+  const char split_char = ',';
+  const char newline_char = '\n';
+  buf[0] = (unsigned char)newline_char;
+  unsigned int char_count = 1;
+  for(int i = 0; i < consts.IMU_ASCII_DATA_SIZE; i++) {
+    for(int j = 0; j < (int)strlen(dummy_ascii_imu_data.at(i)); j++) {
+      buf[char_count] = (unsigned char)dummy_ascii_imu_data.at(i)[j];
       char_count++;
     }
-    return char_count;
+    if(i != consts.IMU_ASCII_DATA_SIZE - 1) buf[char_count] = (unsigned char)split_char;
+    else buf[char_count] = (unsigned char)newline_char;
+    char_count++;
+  }
+  return char_count;
 }
 
 TEST(TestDriver, startCommunication)
@@ -242,17 +262,16 @@ TEST(TestDriver, checkDataFormat_Binary)
 {
   // Expect to check correctly when read data in binary format
   auto mock = create_serial_port_mock();
-  auto data = ReadBinaryTestParam(0);
 
   // 1st: invalid binary data ('R' and 'T' positions are reversed)
   // 2nd: correct binary data ('R' and 'T' are in the correct position)
-  When(Method(mock, readFromDevice)).Do([&](
+  When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_bin_imu_data(buf, true);
     return buf_size;
-  }).Do([&](
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_bin_imu_data(buf, false);
     return buf_size;
   });
 
@@ -269,17 +288,16 @@ TEST(TestDriver, checkDataFormat_ASCII)
 {
   // Expect to check correctly when read data in ASCII format
   auto mock = create_serial_port_mock();
-  auto data = ReadAsciiTestParam(0);
 
   // 1st: invalid ascii data (timestamp is double)
   // 2nd: correct ascii data (timestamp is int)
-  When(Method(mock, readFromDevice)).Do([&](
+  When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_ascii_imu_data(buf, true);
     return buf_size;
-  }).Do([&](
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_ascii_imu_data(buf, false);
     return buf_size;
   });
 
@@ -322,17 +340,16 @@ TEST(TestDriver, readSensorData_Binary)
 {
   // Expect to check the data is correctly updated when binary data is read
   auto mock = create_serial_port_mock();
-  auto data = ReadBinaryTestParam(0);
 
   // 1st: invalid binary data ('R' and 'T' positions are reversed)
   // 2nd: correct binary data ('R' and 'T' are in the correct position)
-  When(Method(mock, readFromDevice)).Do([&](
+  When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_bin_imu_data(buf, true);
     return buf_size;
-  }).Do([&](
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_bin_imu_data(buf, false);
     return buf_size;
   });
 
@@ -353,17 +370,16 @@ TEST(TestDriver, readSensorData_ASCII)
 {
   // Expect to check the data is correctly updated when ascii data is read
   auto mock = create_serial_port_mock();
-  auto data = ReadAsciiTestParam(0);
 
   // 1st: invalid ascii data (timestamp is double)
   // 2nd: correct ascii data (timestamp is int)
-  When(Method(mock, readFromDevice)).Do([&](
+  When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_ascii_imu_data(buf, true);
     return buf_size;
-  }).Do([&](
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_ascii_imu_data(buf, false);
     return buf_size;
   });
 
@@ -422,21 +438,21 @@ TEST_P(ReadBinaryTest, read_binary_test) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    TestDriver,
-    ReadBinaryTest,
-    ::testing::Values(
-      ReadBinaryTestParam(0),
-      ReadBinaryTestParam(1),
-      ReadBinaryTestParam(2),
-      ReadBinaryTestParam(3),
-      ReadBinaryTestParam(4),
-      ReadBinaryTestParam(5),
-      ReadBinaryTestParam(6),
-      ReadBinaryTestParam(7),
-      ReadBinaryTestParam(8),
-      ReadBinaryTestParam(9),
-      ReadBinaryTestParam(10)
-    )
+  TestDriver,
+  ReadBinaryTest,
+  ::testing::Values(
+    ReadBinaryTestParam(0),
+    ReadBinaryTestParam(1),
+    ReadBinaryTestParam(2),
+    ReadBinaryTestParam(3),
+    ReadBinaryTestParam(4),
+    ReadBinaryTestParam(5),
+    ReadBinaryTestParam(6),
+    ReadBinaryTestParam(7),
+    ReadBinaryTestParam(8),
+    ReadBinaryTestParam(9),
+    ReadBinaryTestParam(10)
+  )
 );
 
 class ReadAsciiTest : public testing::TestWithParam<ReadAsciiTestParam> {
@@ -481,19 +497,19 @@ TEST_P(ReadAsciiTest, read_ascii_test) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    TestDriver,
-    ReadAsciiTest,
-    ::testing::Values(
-      ReadAsciiTestParam(0),
-      ReadAsciiTestParam(1),
-      ReadAsciiTestParam(2),
-      ReadAsciiTestParam(3),
-      ReadAsciiTestParam(4),
-      ReadAsciiTestParam(5),
-      ReadAsciiTestParam(6),
-      ReadAsciiTestParam(7),
-      ReadAsciiTestParam(8),
-      ReadAsciiTestParam(9),
-      ReadAsciiTestParam(10)
-    )
+  TestDriver,
+  ReadAsciiTest,
+  ::testing::Values(
+    ReadAsciiTestParam(0),
+    ReadAsciiTestParam(1),
+    ReadAsciiTestParam(2),
+    ReadAsciiTestParam(3),
+    ReadAsciiTestParam(4),
+    ReadAsciiTestParam(5),
+    ReadAsciiTestParam(6),
+    ReadAsciiTestParam(7),
+    ReadAsciiTestParam(8),
+    ReadAsciiTestParam(9),
+    ReadAsciiTestParam(10)
+  )
 );

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -345,9 +345,14 @@ TEST(TestDriver, readSensorData_Binary)
   // Expect to check the data is correctly updated when binary data is read
   auto mock = create_serial_port_mock();
 
-  // 1st: invalid binary data ('R' and 'T' positions are reversed)
-  // 2nd: correct binary data ('R' and 'T' are in the correct position)
+  // 1st: correct binary data ('R' and 'T' are in the correct position)
+  // 2nd: invalid binary data ('R' and 'T' positions are reversed)
+  // 3rd: correct binary data ('R' and 'T' are in the correct position)
   When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    buf_size = create_dummy_bin_imu_data(buf, false);
+    return buf_size;
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
     buf_size = create_dummy_bin_imu_data(buf, true);
     return buf_size;
@@ -360,12 +365,12 @@ TEST(TestDriver, readSensorData_Binary)
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  driver.setBinaryFormat();
-  driver.readSensorData();
+  driver.checkDataFormat(); // 1st
+  driver.readSensorData(); // 2nd
 
   EXPECT_FALSE(driver.hasRefreshedImuData());
 
-  driver.readSensorData();
+  driver.readSensorData(); // 3rd
 
   EXPECT_TRUE(driver.hasRefreshedImuData());
 }
@@ -375,9 +380,14 @@ TEST(TestDriver, readSensorData_ASCII)
   // Expect to check the data is correctly updated when ascii data is read
   auto mock = create_serial_port_mock();
 
-  // 1st: invalid ascii data (timestamp is double)
-  // 2nd: correct ascii data (timestamp is int)
+  // 1st: correct ascii data (timestamp is int)
+  // 2nd: invalid ascii data (timestamp is double)
+  // 3rd: correct ascii data (timestamp is int)
   When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    buf_size = create_dummy_ascii_imu_data(buf, false);
+    return buf_size;
+  }).Do([](
     unsigned char* buf, unsigned int buf_size) {
     buf_size = create_dummy_ascii_imu_data(buf, true);
     return buf_size;
@@ -390,12 +400,12 @@ TEST(TestDriver, readSensorData_ASCII)
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  driver.setAsciiFormat();
-  driver.readSensorData();
+  driver.checkDataFormat(); // 1st
+  driver.readSensorData(); // 2nd
 
   EXPECT_FALSE(driver.hasRefreshedImuData());
 
-  driver.readSensorData();
+  driver.readSensorData(); // 3rd
 
   EXPECT_TRUE(driver.hasRefreshedImuData());
 }
@@ -411,13 +421,13 @@ TEST_P(ReadBinaryTest, read_binary_test) {
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  When(Method(mock, readFromDevice)).Do([&](
+  When(Method(mock, readFromDevice)).AlwaysDo([&](
     unsigned char* buf, unsigned int buf_size) {
     buf_size = create_dummy_bin_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
-  driver.setBinaryFormat();
+  driver.checkDataFormat();
   driver.readSensorData();
 
   rclcpp::Time timestamp;
@@ -470,13 +480,13 @@ TEST_P(ReadAsciiTest, read_ascii_test) {
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  When(Method(mock, readFromDevice)).Do([&](
+  When(Method(mock, readFromDevice)).AlwaysDo([&](
     unsigned char* buf, unsigned int buf_size) {
     buf_size = create_dummy_ascii_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
-  driver.setAsciiFormat();
+  driver.checkDataFormat();
   driver.readSensorData();
 
   rclcpp::Time timestamp;

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -36,6 +36,7 @@
 #include "fakeit.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp"
+#include <iostream>
 
 using fakeit::Mock;
 using fakeit::When;
@@ -72,7 +73,14 @@ unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid) {
   return consts.IMU_BIN_DATA_SIZE;
 }
 
-unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid) {
+std::string double_to_string(double val) {
+    std::string str = std::to_string(val);
+    str.resize(8, '0');
+    return str;
+}
+
+unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid,
+                                         double *gyro, double *acc, double *mag, double temp) {
     rt_usb_9axisimu::Consts consts;
     std::vector<const char*> dummy_ascii_imu_data(consts.IMU_ASCII_DATA_SIZE); 
     if (is_invalid) {
@@ -80,16 +88,16 @@ unsigned int create_dummy_ascii_imu_data(unsigned char *buf, bool is_invalid) {
     } else {
       dummy_ascii_imu_data[consts.IMU_ASCII_TIMESTAMP] = "0";
     }
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = "0.000000";
-    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = "0.000000";
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_X] = double_to_string(gyro[0]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Y] = double_to_string(gyro[1]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_GYRO_Z] = double_to_string(gyro[2]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_X] = double_to_string(acc[0]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Y] = double_to_string(acc[1]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_ACC_Z] = double_to_string(acc[2]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_X] = double_to_string(mag[0]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Y] = double_to_string(mag[1]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_MAG_Z] = double_to_string(mag[2]).c_str();
+    dummy_ascii_imu_data[consts.IMU_ASCII_TEMP] = double_to_string(temp).c_str();
     const char split_char = ',';
     const char newline_char = '\n';
     buf[0] = (unsigned char)newline_char;
@@ -167,11 +175,19 @@ TEST(TestDriver, checkDataFormat_ASCII)
   // 2nd: correct ascii data (timestamp is int)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, true);
+    double gyro[] = {0.0, 0.0, 0.0};
+    double acc[] = {0.0, 0.0, 0.0};
+    double mag[] = {0.0, 0.0, 0.0};
+    double temp = 0.0;
+    buf_size = create_dummy_ascii_imu_data(buf, true, gyro, acc, mag, temp);
     return buf_size;
   }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, false);
+    double gyro[] = {0.0, 0.0, 0.0};
+    double acc[] = {0.0, 0.0, 0.0};
+    double mag[] = {0.0, 0.0, 0.0};
+    double temp = 0.0;
+    buf_size = create_dummy_ascii_imu_data(buf, false, gyro, acc, mag, temp);
     return buf_size;
   });
 
@@ -249,11 +265,19 @@ TEST(TestDriver, readSensorData_ASCII)
   // 2nd: correct ascii data (timestamp is int)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, true);
+    double gyro[] = {0.0, 0.0, 0.0};
+    double acc[] = {0.0, 0.0, 0.0};
+    double mag[] = {0.0, 0.0, 0.0};
+    double temp = 0.0;
+    buf_size = create_dummy_ascii_imu_data(buf, true, gyro, acc, mag, temp);
     return buf_size;
   }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, false);
+    double gyro[] = {0.0, 0.0, 0.0};
+    double acc[] = {0.0, 0.0, 0.0};
+    double mag[] = {0.0, 0.0, 0.0};
+    double temp = 0.0;
+    buf_size = create_dummy_ascii_imu_data(buf, false, gyro, acc, mag, temp);
     return buf_size;
   });
 
@@ -285,7 +309,11 @@ TEST(TestDriver, check_convert_when_read_ASCII) {
   // case 1: zero
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_ascii_imu_data(buf, false);
+    double gyro[] = {0.0, 0.0, 0.0};
+    double acc[] = {0.0, 0.0, 0.0};
+    double mag[] = {0.0, 0.0, 0.0};
+    double temp = 0.0;
+    buf_size = create_dummy_ascii_imu_data(buf, false, gyro, acc, mag, temp);
     return buf_size;
   });
 

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -53,7 +53,14 @@ Mock<SerialPort> create_serial_port_mock(void) {
   return mock;
 }
 
-unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid) {
+// Expect that short int is 2 bytes.
+unsigned char short_int_to_byte(short int val, bool is_low) {
+  if (is_low) return (val >> 0) & 0xFF;
+  else return (val >> 8) & 0xFF;
+}
+
+unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
+                                       short int *gyro, short int *acc, short int *mag, short int temp) {
   rt_usb_9axisimu::Consts consts;
   unsigned char dummy_bin_imu_data[consts.IMU_BIN_DATA_SIZE] = {0};
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_FF0] = 0xff;
@@ -67,6 +74,26 @@ unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid) {
   }
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID0] = 0x39;
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_L] = short_int_to_byte(acc[0], true);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_X_H] = short_int_to_byte(acc[0], false);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_L] = short_int_to_byte(acc[1], true);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_H] = short_int_to_byte(acc[1], false);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_L] = short_int_to_byte(acc[2], true);
+  dummy_bin_imu_data[consts.IMU_BIN_ACC_Z_H] = short_int_to_byte(acc[2], false);
+  dummy_bin_imu_data[consts.IMU_BIN_TEMP_L] = short_int_to_byte(temp, true);
+  dummy_bin_imu_data[consts.IMU_BIN_TEMP_H] = short_int_to_byte(temp, false);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_L] = short_int_to_byte(gyro[0], true);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_X_H] = short_int_to_byte(gyro[0], false);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_L] = short_int_to_byte(gyro[1], true);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Y_H] = short_int_to_byte(gyro[1], false);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_L] = short_int_to_byte(gyro[2], true);
+  dummy_bin_imu_data[consts.IMU_BIN_GYRO_Z_H] = short_int_to_byte(gyro[2], false);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_L] = short_int_to_byte(mag[0], true);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_X_H] = short_int_to_byte(mag[0], false);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_L] = short_int_to_byte(mag[1], true);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Y_H] = short_int_to_byte(mag[1], false);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_L] = short_int_to_byte(mag[2], true);
+  dummy_bin_imu_data[consts.IMU_BIN_MAG_Z_H] = short_int_to_byte(mag[2], false);
   for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++) {
     buf[i] = dummy_bin_imu_data[i];
   }
@@ -149,11 +176,19 @@ TEST(TestDriver, checkDataFormat_Binary)
   // 2nd: correct binary data ('R' and 'T' are in the correct position)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, true);
+    short int gyro[] = {0, 0, 0};
+    short int acc[] = {0, 0, 0};
+    short int mag[] = {0, 0, 0};
+    short int temp = 0;
+    buf_size = create_dummy_bin_imu_data(buf, true, gyro, acc, mag, temp);
     return buf_size;
   }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, false);
+    short int gyro[] = {0, 0, 0};
+    short int acc[] = {0, 0, 0};
+    short int mag[] = {0, 0, 0};
+    short int temp = 0;
+    buf_size = create_dummy_bin_imu_data(buf, false, gyro, acc, mag, temp);
     return buf_size;
   });
 
@@ -235,11 +270,19 @@ TEST(TestDriver, readSensorData_Binary)
   // 2nd: correct binary data ('R' and 'T' are in the correct position)
   When(Method(mock, readFromDevice)).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, true);
+    short int gyro[] = {0, 0, 0};
+    short int acc[] = {0, 0, 0};
+    short int mag[] = {0, 0, 0};
+    short int temp = 0;
+    buf_size = create_dummy_bin_imu_data(buf, true, gyro, acc, mag, temp);
     return buf_size;
   }).Do([](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, false);
+    short int gyro[] = {0, 0, 0};
+    short int acc[] = {0, 0, 0};
+    short int mag[] = {0, 0, 0};
+    short int temp = 0;
+    buf_size = create_dummy_bin_imu_data(buf, false, gyro, acc, mag, temp);
     return buf_size;
   });
 
@@ -292,6 +335,46 @@ TEST(TestDriver, readSensorData_ASCII)
   driver.readSensorData();
 
   EXPECT_TRUE(driver.hasRefreshedImuData());
+}
+
+TEST(TestDriver, check_convert_when_read_Binary) {
+  // Expect to check the data is correctly converted when binary data is read
+  auto mock = create_serial_port_mock();
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  driver.setBinaryFormat();
+
+  rclcpp::Time timestamp;
+  const double abs_error = 1e-9;
+
+  // case 1: zero
+  When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    short int gyro[] = {0, 0, 0};
+    short int acc[] = {0, 0, 0};
+    short int mag[] = {0, 0, 0};
+    short int temp = 0;
+    buf_size = create_dummy_bin_imu_data(buf, true, gyro, acc, mag, temp);
+    return buf_size;
+  });
+
+  auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
+  auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
+  auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
+
+  const double zero = 0.0;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, zero, abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, zero, abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, zero, abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, zero, abs_error);
+  EXPECT_NEAR(imu_data_temperature->data, zero, abs_error);
 }
 
 TEST(TestDriver, check_convert_when_read_ASCII) {

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -36,11 +36,60 @@
 #include "fakeit.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp"
 #include "rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp"
-#include <iostream>
 
 using fakeit::Mock;
 using fakeit::When;
 using rt_usb_9axisimu::SerialPort;
+
+class ReadBinaryTestParam {
+public:
+  short int gyro[3];
+  short int acc[3];
+  short int mag[3];
+  short int temp;
+  double ans_gyro[3];
+  double ans_acc[3];
+  double ans_mag[3];
+  double ans_temp;
+
+  ReadBinaryTestParam (int case_num) {
+    if (case_num == 0) {
+      gyro[0] = gyro[1] = gyro[2] = 0;
+      acc[0] = acc[1] = acc[2] = 0;
+      mag[0] = mag[1] = mag[2] = 0;
+      temp = 0;
+      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = 0.0;
+      ans_acc[0] = ans_acc[1] = ans_acc[2] = 0.0;
+      ans_mag[0] = ans_mag[1] = ans_mag[2] = 0.0;
+      ans_temp = 0.0;
+    }
+  }
+};
+
+class ReadAsciiTestParam {
+public:
+  double gyro[3];
+  double acc[3];
+  double mag[3];
+  double temp;
+  double ans_gyro[3];
+  double ans_acc[3];
+  double ans_mag[3];
+  double ans_temp;
+
+  ReadAsciiTestParam (int case_num) {
+    if (case_num == 0) {
+      gyro[0] = gyro[1] = gyro[2] = 0.0;
+      acc[0] = acc[1] = acc[2] = 0.0;
+      mag[0] = mag[1] = mag[2] = 0.0;
+      temp = 0.0;
+      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = 0.0;
+      ans_acc[0] = ans_acc[1] = ans_acc[2] = 0.0;
+      ans_mag[0] = ans_mag[1] = ans_mag[2] = 0.0;
+      ans_temp = 0.0;
+    }
+  }
+};
 
 Mock<SerialPort> create_serial_port_mock(void) {
   Mock<SerialPort> mock;
@@ -171,24 +220,17 @@ TEST(TestDriver, checkDataFormat_Binary)
 {
   // Expect to check correctly when read data in binary format
   auto mock = create_serial_port_mock();
+  auto data = ReadBinaryTestParam(0);
 
   // 1st: invalid binary data ('R' and 'T' positions are reversed)
   // 2nd: correct binary data ('R' and 'T' are in the correct position)
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    short int gyro[] = {0, 0, 0};
-    short int acc[] = {0, 0, 0};
-    short int mag[] = {0, 0, 0};
-    short int temp = 0;
-    buf_size = create_dummy_bin_imu_data(buf, true, gyro, acc, mag, temp);
+    buf_size = create_dummy_bin_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
-  }).Do([](
+  }).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    short int gyro[] = {0, 0, 0};
-    short int acc[] = {0, 0, 0};
-    short int mag[] = {0, 0, 0};
-    short int temp = 0;
-    buf_size = create_dummy_bin_imu_data(buf, false, gyro, acc, mag, temp);
+    buf_size = create_dummy_bin_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
@@ -205,24 +247,17 @@ TEST(TestDriver, checkDataFormat_ASCII)
 {
   // Expect to check correctly when read data in ASCII format
   auto mock = create_serial_port_mock();
+  auto data = ReadAsciiTestParam(0);
 
   // 1st: invalid ascii data (timestamp is double)
   // 2nd: correct ascii data (timestamp is int)
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    double gyro[] = {0.0, 0.0, 0.0};
-    double acc[] = {0.0, 0.0, 0.0};
-    double mag[] = {0.0, 0.0, 0.0};
-    double temp = 0.0;
-    buf_size = create_dummy_ascii_imu_data(buf, true, gyro, acc, mag, temp);
+    buf_size = create_dummy_ascii_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
-  }).Do([](
+  }).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    double gyro[] = {0.0, 0.0, 0.0};
-    double acc[] = {0.0, 0.0, 0.0};
-    double mag[] = {0.0, 0.0, 0.0};
-    double temp = 0.0;
-    buf_size = create_dummy_ascii_imu_data(buf, false, gyro, acc, mag, temp);
+    buf_size = create_dummy_ascii_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
@@ -265,24 +300,17 @@ TEST(TestDriver, readSensorData_Binary)
 {
   // Expect to check the data is correctly updated when binary data is read
   auto mock = create_serial_port_mock();
+  auto data = ReadBinaryTestParam(0);
 
   // 1st: invalid binary data ('R' and 'T' positions are reversed)
   // 2nd: correct binary data ('R' and 'T' are in the correct position)
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    short int gyro[] = {0, 0, 0};
-    short int acc[] = {0, 0, 0};
-    short int mag[] = {0, 0, 0};
-    short int temp = 0;
-    buf_size = create_dummy_bin_imu_data(buf, true, gyro, acc, mag, temp);
+    buf_size = create_dummy_bin_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
-  }).Do([](
+  }).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    short int gyro[] = {0, 0, 0};
-    short int acc[] = {0, 0, 0};
-    short int mag[] = {0, 0, 0};
-    short int temp = 0;
-    buf_size = create_dummy_bin_imu_data(buf, false, gyro, acc, mag, temp);
+    buf_size = create_dummy_bin_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
@@ -303,24 +331,17 @@ TEST(TestDriver, readSensorData_ASCII)
 {
   // Expect to check the data is correctly updated when ascii data is read
   auto mock = create_serial_port_mock();
+  auto data = ReadAsciiTestParam(0);
 
   // 1st: invalid ascii data (timestamp is double)
   // 2nd: correct ascii data (timestamp is int)
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    double gyro[] = {0.0, 0.0, 0.0};
-    double acc[] = {0.0, 0.0, 0.0};
-    double mag[] = {0.0, 0.0, 0.0};
-    double temp = 0.0;
-    buf_size = create_dummy_ascii_imu_data(buf, true, gyro, acc, mag, temp);
+    buf_size = create_dummy_ascii_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
-  }).Do([](
+  }).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    double gyro[] = {0.0, 0.0, 0.0};
-    double acc[] = {0.0, 0.0, 0.0};
-    double mag[] = {0.0, 0.0, 0.0};
-    double temp = 0.0;
-    buf_size = create_dummy_ascii_imu_data(buf, false, gyro, acc, mag, temp);
+    buf_size = create_dummy_ascii_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
@@ -337,82 +358,92 @@ TEST(TestDriver, readSensorData_ASCII)
   EXPECT_TRUE(driver.hasRefreshedImuData());
 }
 
-TEST(TestDriver, check_convert_when_read_Binary) {
+class ReadBinaryTest : public testing::TestWithParam<ReadBinaryTestParam> {
+};
+
+TEST_P(ReadBinaryTest, read_binary_test) {
   // Expect to check the data is correctly converted when binary data is read
   auto mock = create_serial_port_mock();
+  auto data = GetParam();
 
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
   driver.setBinaryFormat();
 
-  rclcpp::Time timestamp;
-  const double abs_error = 1e-9;
-
-  // case 1: zero
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    short int gyro[] = {0, 0, 0};
-    short int acc[] = {0, 0, 0};
-    short int mag[] = {0, 0, 0};
-    short int temp = 0;
-    buf_size = create_dummy_bin_imu_data(buf, true, gyro, acc, mag, temp);
+    buf_size = create_dummy_bin_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
+  rclcpp::Time timestamp;
   auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
   auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
   auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
 
-  const double zero = 0.0;
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.x, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.y, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.z, zero, abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.x, zero, abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.y, zero, abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.z, zero, abs_error);
-  EXPECT_NEAR(imu_data_temperature->data, zero, abs_error);
+  const double abs_error = 1e-9;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error);
+  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error);
 }
 
-TEST(TestDriver, check_convert_when_read_ASCII) {
+INSTANTIATE_TEST_SUITE_P(
+    TestDriver,
+    ReadBinaryTest,
+    ::testing::Values(
+      ReadBinaryTestParam(0)
+    )
+);
+
+class ReadAsciiTest : public testing::TestWithParam<ReadAsciiTestParam> {
+};
+
+TEST_P(ReadAsciiTest, read_ascii_test) {
   // Expect to check the data is correctly converted when ascii data is read
   auto mock = create_serial_port_mock();
+  auto data = GetParam();
 
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
   driver.setAsciiFormat();
 
-  rclcpp::Time timestamp;
-  const double abs_error = 1e-9;
-
-  // case 1: zero
-  When(Method(mock, readFromDevice)).Do([](
+  When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    double gyro[] = {0.0, 0.0, 0.0};
-    double acc[] = {0.0, 0.0, 0.0};
-    double mag[] = {0.0, 0.0, 0.0};
-    double temp = 0.0;
-    buf_size = create_dummy_ascii_imu_data(buf, false, gyro, acc, mag, temp);
+    buf_size = create_dummy_ascii_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
+  rclcpp::Time timestamp;
   auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
   auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
   auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
 
-  const double zero = 0.0;
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.x, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.y, zero, abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.z, zero, abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.x, zero, abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.y, zero, abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.z, zero, abs_error);
-  EXPECT_NEAR(imu_data_temperature->data, zero, abs_error);
+  const double abs_error = 1e-9;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error);
+  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    TestDriver,
+    ReadAsciiTest,
+    ::testing::Values(
+      ReadAsciiTestParam(0)
+    )
+);

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -52,17 +52,32 @@ public:
   double ans_mag[3];
   double ans_temp;
 
+  void set_data (short int test_val) {
+      rt_usb_9axisimu::Consts consts;
+      const int test_firmfare_ver = 18;
+      consts.ChangeConvertor(test_firmfare_ver);
+      gyro[0] = gyro[1] = gyro[2] = test_val;
+      acc[0] = acc[1] = acc[2] = test_val;
+      mag[0] = mag[1] = mag[2] = test_val;
+      temp = test_val;
+      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = (double)(test_val / consts.CONVERTOR_RAW2DPS * consts.CONVERTOR_D2R);
+      ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(test_val / consts.CONVERTOR_RAW2G * consts.CONVERTOR_G2A);
+      ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(test_val * consts.CONVERTOR_RAW2UT / consts.CONVERTOR_UT2T);
+      ans_temp = (double)(test_val / consts.CONVERTOR_RAW2C_1 + consts.CONVERTOR_RAW2C_2);
+  }
+
   ReadBinaryTestParam (int case_num) {
-    if (case_num == 0) {
-      gyro[0] = gyro[1] = gyro[2] = 0;
-      acc[0] = acc[1] = acc[2] = 0;
-      mag[0] = mag[1] = mag[2] = 0;
-      temp = 0;
-      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = 0.0;
-      ans_acc[0] = ans_acc[1] = ans_acc[2] = 0.0;
-      ans_mag[0] = ans_mag[1] = ans_mag[2] = 0.0;
-      ans_temp = 0.0;
-    }
+    if (case_num == 0) set_data(0); // zero
+    else if (case_num == 1) set_data(32767); // max
+    else if (case_num == 2) set_data(-32768); // min
+    else if (case_num == 3) set_data(32766); // boundary
+    else if (case_num == 4) set_data(-32767); // boundary
+    else if (case_num == 5) set_data(1); // random
+    else if (case_num == 6) set_data(-1); // random
+    else if (case_num == 7) set_data(999); // random
+    else if (case_num == 8) set_data(-999); // random
+    else if (case_num == 9) set_data(12345); // random
+    else if (case_num == 10) set_data(-12345); // random
   }
 };
 
@@ -77,17 +92,32 @@ public:
   double ans_mag[3];
   double ans_temp;
 
+  void set_data (double gyro_val, double acc_val, double mag_val, double temp_val) {
+      rt_usb_9axisimu::Consts consts;
+      const int test_firmfare_ver = 18;
+      consts.ChangeConvertor(test_firmfare_ver);
+      gyro[0] = gyro[1] = gyro[2] = gyro_val;
+      acc[0] = acc[1] = acc[2] = acc_val;
+      mag[0] = mag[1] = mag[2] = mag_val;
+      temp = temp_val;
+      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = gyro_val;
+      ans_acc[0] = ans_acc[1] = ans_acc[2] = (double)(acc_val * consts.CONVERTOR_G2A);
+      ans_mag[0] = ans_mag[1] = ans_mag[2] = (double)(mag_val / consts.CONVERTOR_UT2T);
+      ans_temp = temp_val;
+  }
+
   ReadAsciiTestParam (int case_num) {
-    if (case_num == 0) {
-      gyro[0] = gyro[1] = gyro[2] = 0.0;
-      acc[0] = acc[1] = acc[2] = 0.0;
-      mag[0] = mag[1] = mag[2] = 0.0;
-      temp = 0.0;
-      ans_gyro[0] = ans_gyro[1] = ans_gyro[2] = 0.0;
-      ans_acc[0] = ans_acc[1] = ans_acc[2] = 0.0;
-      ans_mag[0] = ans_mag[1] = ans_mag[2] = 0.0;
-      ans_temp = 0.0;
-    }
+    if(case_num == 0) set_data(0.0, 0.0, 0.0, 0.0); // zero
+    else if(case_num == 1) set_data(34.906585, 16.0, 4800.0, 85.0); // max
+    else if(case_num == 2) set_data(-34.906585, -16.0, -4800.0, -40.0); // min
+    else if(case_num == 3) set_data(0.00107, 0.0005, 0.14649, 0.0026); // resolution
+    else if(case_num == 4) set_data(-0.00107, -0.0005, -0.14649, -0.00122); // resolution
+    else if(case_num == 5) set_data(0.1, 0.1, 0.1, 0.1); // random
+    else if(case_num == 6) set_data(-0.1, -0.1, -0.1, -0.1); // random
+    else if(case_num == 7) set_data(1.0, 1.0, 1.0, 1.0); // random
+    else if(case_num == 8) set_data(-1.0, -1.0, -1.0, -1.0); // random
+    else if(case_num == 9) set_data(12.34567, 12.34567, 12.34567, 12.34567); // random
+    else if(case_num == 10) set_data(-12.34567, -12.34567, -12.34567, -12.34567); // random
   }
 };
 
@@ -123,6 +153,8 @@ unsigned int create_dummy_bin_imu_data(unsigned char *buf, bool is_invalid,
   }
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID0] = 0x39;
   dummy_bin_imu_data[consts.IMU_BIN_HEADER_ID1] = 0x41;
+  dummy_bin_imu_data[consts.IMU_BIN_FIRMWARE] = 0x12;
+  dummy_bin_imu_data[consts.IMU_BIN_TIMESTAMP] = 0x00;
   dummy_bin_imu_data[consts.IMU_BIN_ACC_X_L] = short_int_to_byte(acc[0], true);
   dummy_bin_imu_data[consts.IMU_BIN_ACC_X_H] = short_int_to_byte(acc[0], false);
   dummy_bin_imu_data[consts.IMU_BIN_ACC_Y_L] = short_int_to_byte(acc[1], true);
@@ -369,42 +401,67 @@ TEST_P(ReadBinaryTest, read_binary_test) {
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  driver.setBinaryFormat();
-
   When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
-    buf_size = create_dummy_bin_imu_data(buf, true, data.gyro, data.acc, data.mag, data.temp);
+    buf_size = create_dummy_bin_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
+
+  driver.setBinaryFormat();
+  driver.readSensorData();
 
   rclcpp::Time timestamp;
   auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
   auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
   auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
 
-  const double abs_error = 1e-9;
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error);
-  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error);
+  const double abs_error_acc = 1e-3;
+  const double abs_error_gyro = 1e-3;
+  const double abs_error_mag = 1e-7;
+  const double abs_error_temp = 1e-3;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error_gyro);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error_mag);
+  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error_temp);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     TestDriver,
     ReadBinaryTest,
     ::testing::Values(
-      ReadBinaryTestParam(0)
+      ReadBinaryTestParam(0),
+      ReadBinaryTestParam(1),
+      ReadBinaryTestParam(2),
+      ReadBinaryTestParam(3),
+      ReadBinaryTestParam(4),
+      ReadBinaryTestParam(5),
+      ReadBinaryTestParam(6),
+      ReadBinaryTestParam(7),
+      ReadBinaryTestParam(8),
+      ReadBinaryTestParam(9),
+      ReadBinaryTestParam(10)
     )
 );
 
 class ReadAsciiTest : public testing::TestWithParam<ReadAsciiTestParam> {
 };
+
+int16_t comb(unsigned char data_h, unsigned char data_l)
+{
+  int16_t short_data = 0;
+
+  short_data = data_h;
+  short_data = short_data << 8;
+  short_data |= data_l;
+
+  return short_data;
+}
 
 TEST_P(ReadAsciiTest, read_ascii_test) {
   // Expect to check the data is correctly converted when ascii data is read
@@ -414,36 +471,50 @@ TEST_P(ReadAsciiTest, read_ascii_test) {
   RtUsb9axisimuRosDriver driver(
     std::unique_ptr<SerialPort>(&mock.get()));
 
-  driver.setAsciiFormat();
-
   When(Method(mock, readFromDevice)).Do([&](
     unsigned char* buf, unsigned int buf_size) {
     buf_size = create_dummy_ascii_imu_data(buf, false, data.gyro, data.acc, data.mag, data.temp);
     return buf_size;
   });
 
+  driver.setAsciiFormat();
+  driver.readSensorData();
+
   rclcpp::Time timestamp;
   auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
   auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
   auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
 
-  const double abs_error = 1e-9;
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error);
-  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error);
-  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error);
-  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error);
-  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error);
+  const double abs_error_acc = 1e-3;
+  const double abs_error_gyro = 1e-3;
+  const double abs_error_mag = 1e-7;
+  const double abs_error_temp = 1e-3;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error_gyro);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error_mag);
+  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error_temp);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     TestDriver,
     ReadAsciiTest,
     ::testing::Values(
-      ReadAsciiTestParam(0)
+      ReadAsciiTestParam(0),
+      ReadAsciiTestParam(1),
+      ReadAsciiTestParam(2),
+      ReadAsciiTestParam(3),
+      ReadAsciiTestParam(4),
+      ReadAsciiTestParam(5),
+      ReadAsciiTestParam(6),
+      ReadAsciiTestParam(7),
+      ReadAsciiTestParam(8),
+      ReadAsciiTestParam(9),
+      ReadAsciiTestParam(10)
     )
 );

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -209,3 +209,57 @@ TEST(TestDriver, checkDataFormat_not_Binary_or_ASCII)
   EXPECT_FALSE(driver.hasBinaryDataFormat());
   EXPECT_FALSE(driver.hasAsciiDataFormat());
 }
+
+TEST(TestDriver, readSensorData_Binary)
+{
+  auto mock = create_serial_port_mock();
+
+  When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    buf_size = create_dummy_bin_imu_data(buf, true);
+    return buf_size;
+  }).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    buf_size = create_dummy_bin_imu_data(buf, false);
+    return buf_size;
+  });
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  driver.setBinaryFormat();
+  driver.readSensorData();
+
+  EXPECT_FALSE(driver.hasRefreshedImuData());
+
+  driver.readSensorData();
+
+  EXPECT_TRUE(driver.hasRefreshedImuData());
+}
+
+TEST(TestDriver, readSensorData_ASCII)
+{
+  auto mock = create_serial_port_mock();
+
+  When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    buf_size = create_dummy_ascii_imu_data(buf, true);
+    return buf_size;
+  }).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    buf_size = create_dummy_ascii_imu_data(buf, false);
+    return buf_size;
+  });
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  driver.setAsciiFormat();
+  driver.readSensorData();
+
+  EXPECT_FALSE(driver.hasRefreshedImuData());
+
+  driver.readSensorData();
+
+  EXPECT_TRUE(driver.hasRefreshedImuData());
+}

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -269,3 +269,39 @@ TEST(TestDriver, readSensorData_ASCII)
 
   EXPECT_TRUE(driver.hasRefreshedImuData());
 }
+
+TEST(TestDriver, check_convert_when_read_ASCII) {
+  // Expect to check the data is correctly converted when ascii data is read
+  auto mock = create_serial_port_mock();
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  driver.setAsciiFormat();
+
+  rclcpp::Time timestamp;
+  const double abs_error = 1e-9;
+
+  // case 1: zero
+  When(Method(mock, readFromDevice)).Do([](
+    unsigned char* buf, unsigned int buf_size) {
+    buf_size = create_dummy_ascii_imu_data(buf, false);
+    return buf_size;
+  });
+
+  auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
+  auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
+  auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
+
+  const double zero = 0.0;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, zero, abs_error);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, zero, abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, zero, abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, zero, abs_error);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, zero, abs_error);
+  EXPECT_NEAR(imu_data_temperature->data, zero, abs_error);
+}


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
RtUsb9axisimuRosDriver::readSensorData()を実行した後に以下の検証を行うテストを追加します。

- センサから正しくデータを取得できているか
- センサから取得したデータが正しく変換されているか

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
`colcon test`で全てのテストが通ることを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->
各センサデータの値の正誤判定において設定した精度が正しいか確認いただきたいです。

該当箇所：https://github.com/rt-net/rt_usb_9axisimu_driver/blob/add_read_test/test/test_driver.cpp#L418

下記の参考ページによると16bitの浮動小数点数では精度が11bit（10進数では3桁程度）ということなので、現状の実装では小数点第3位まで正しいか確認しています。

参考：https://ja.wikipedia.org/wiki/%E5%8D%8A%E7%B2%BE%E5%BA%A6%E6%B5%AE%E5%8B%95%E5%B0%8F%E6%95%B0%E7%82%B9%E6%95%B0

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
