### PR TITLE
Fix to get the latest data

### DIFF
--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
@@ -106,7 +106,7 @@ public:
     IMU_ASCII_DATA_SIZE
   };
 
-  static constexpr int READ_BUFFER_SIZE = 256;
+  static constexpr int READ_BUFFER_SIZE = 1024;
 
   // Convertor
   const double CONVERTOR_RAW2G;

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu.hpp
@@ -106,7 +106,7 @@ public:
     IMU_ASCII_DATA_SIZE
   };
 
-  static constexpr int READ_BUFFER_SIZE = 1024;
+  static constexpr int READ_BUFFER_SIZE = 512;
 
   // Convertor
   const double CONVERTOR_RAW2G;

--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -46,6 +46,34 @@
 
 class RtUsb9axisimuRosDriver
 {
+public:
+  explicit RtUsb9axisimuRosDriver(std::string serialport);
+  RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port);
+  ~RtUsb9axisimuRosDriver();
+
+  enum ReadStatus
+  {
+    SUCCESS = 0,
+    NEED_TO_CONTINUE,
+    FAILURE
+  };
+
+  void setImuFrameIdName(std::string frame_id);
+  void setImuPortName(std::string port);
+  void setImuStdDev(double linear_acceleration, double angular_velocity, double magnetic_field);
+
+  bool startCommunication();
+  void stopCommunication(void);
+  void checkDataFormat(const double timeout = 5.0);
+  bool hasAsciiDataFormat(void);
+  bool hasBinaryDataFormat(void);
+  bool hasRefreshedImuData(void);
+
+  std::unique_ptr<sensor_msgs::msg::Imu> getImuRawDataUniquePtr(const rclcpp::Time timestamp);
+  std::unique_ptr<sensor_msgs::msg::MagneticField> getImuMagUniquePtr(const rclcpp::Time timestamp);
+  std::unique_ptr<std_msgs::msg::Float64> getImuTemperatureUniquePtr(void);
+  ReadStatus readSensorData();
+
 private:
   std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port_;
 
@@ -79,31 +107,10 @@ private:
   // Method to extract binary sensor data from communication buffer
   rt_usb_9axisimu::ImuData<int16_t> extractBinarySensorData(unsigned char * imu_data_buf);
   bool isBinarySensorData(unsigned char * imu_data_buf, unsigned int data_size);
-  bool readBinaryData(void);
+  ReadStatus readBinaryData(void);
   bool isAsciiSensorData(unsigned char * imu_data_buf, unsigned int data_size);
   bool isValidAsciiSensorData(std::vector<std::string> imu_data_vector_buf);
-  bool readAsciiData(void);
-
-public:
-  explicit RtUsb9axisimuRosDriver(std::string serialport);
-  RtUsb9axisimuRosDriver(std::unique_ptr<rt_usb_9axisimu::SerialPort> serial_port);
-  ~RtUsb9axisimuRosDriver();
-
-  void setImuFrameIdName(std::string frame_id);
-  void setImuPortName(std::string port);
-  void setImuStdDev(double linear_acceleration, double angular_velocity, double magnetic_field);
-
-  bool startCommunication();
-  void stopCommunication(void);
-  void checkDataFormat(const double timeout = 5.0);
-  bool hasAsciiDataFormat(void);
-  bool hasBinaryDataFormat(void);
-  bool hasRefreshedImuData(void);
-
-  std::unique_ptr<sensor_msgs::msg::Imu> getImuRawDataUniquePtr(const rclcpp::Time timestamp);
-  std::unique_ptr<sensor_msgs::msg::MagneticField> getImuMagUniquePtr(const rclcpp::Time timestamp);
-  std::unique_ptr<std_msgs::msg::Float64> getImuTemperatureUniquePtr(void);
-  bool readSensorData();
+  ReadStatus readAsciiData(void);
 };
 
 #endif  // RT_USB_9AXISIMU_DRIVER__RT_USB_9AXISIMU_DRIVER_HPP_

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -138,7 +138,7 @@ RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readBinaryData(void)
     }
   }
 
-  for(int i = 0; i < read_data_size; i++){
+  for(int i = 0; i < consts.IMU_BIN_DATA_SIZE; i++){
     imu_binary_data_buffer.push_back(read_data_buf[i+buf_start_idx]);
   }
 
@@ -235,9 +235,16 @@ RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readAsciiData(void)
   }
 
   int buf_start_idx = 0;
-  for (int i = 0; i < data_size_of_buf-consts.IMU_ASCII_DATA_SIZE; i++) {
+  bool newline_flag = false;
+  for (int i = data_size_of_buf-1; i >= 0; i--) {
     if(imu_data_buf[i] == '\n') {
-      buf_start_idx = i;
+      if(newline_flag) {
+        buf_start_idx = i;
+        break;
+      }
+      else if(!newline_flag) {
+        newline_flag = true;
+      }
     }
   }
 

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -131,7 +131,7 @@ RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readBinaryData(void)
   }
 
   int buf_start_idx = 0;
-  for(int i = 0; i < read_data_size-3; i++) {
+  for(int i = 0; i < read_data_size-consts.IMU_BIN_DATA_SIZE+1; i++) {
     if(read_data_buf[i] == 0xff && read_data_buf[i+1] == 0xff &&
        read_data_buf[i+2] == 'R' && read_data_buf[i+3] == 'T') {
       buf_start_idx = i;

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -110,7 +110,7 @@ bool RtUsb9axisimuRosDriver::isBinarySensorData(unsigned char * imu_data_buf, un
   return false;
 }
 
-bool RtUsb9axisimuRosDriver::readBinaryData(void)
+RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readBinaryData(void)
 {
   static std::vector<unsigned char> imu_binary_data_buffer;
   unsigned char read_data_buf[consts.READ_BUFFER_SIZE];
@@ -120,14 +120,14 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
     consts.IMU_BIN_DATA_SIZE - imu_binary_data_buffer.size());
 
   if(read_data_size == 0){  // The device was unplugged.
-    return false;
+    return RtUsb9axisimuRosDriver::ReadStatus::FAILURE;
   }
 
   if(read_data_size < 0){  // read() returns error code.
-    if(errno == EAGAIN || errno == EWOULDBLOCK){  // Wainting for data.
-      return true;
+    if(errno == EAGAIN || errno == EWOULDBLOCK){  // Waiting for data.
+      return RtUsb9axisimuRosDriver::ReadStatus::NEED_TO_CONTINUE;
     }else{
-      return false;
+      return RtUsb9axisimuRosDriver::ReadStatus::FAILURE;
     }
   }
 
@@ -136,12 +136,12 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
   }
 
   if (imu_binary_data_buffer.size() < consts.IMU_BIN_DATA_SIZE){
-    return true;
+    return RtUsb9axisimuRosDriver::ReadStatus::NEED_TO_CONTINUE;
   }
 
   if (isBinarySensorData(imu_binary_data_buffer.data(), imu_binary_data_buffer.size()) == false) {
     imu_binary_data_buffer.clear();
-    return false;
+    return RtUsb9axisimuRosDriver::ReadStatus::FAILURE;
   }
 
   auto imu_rawdata = extractBinarySensorData(imu_binary_data_buffer.data());
@@ -151,7 +151,7 @@ bool RtUsb9axisimuRosDriver::readBinaryData(void)
   sensor_data_.convertRawDataUnit();        // Convert raw data to physical quantity
   has_refreshed_imu_data_ = true;
 
-  return true;
+  return RtUsb9axisimuRosDriver::ReadStatus::SUCCESS;
 }
 
 bool RtUsb9axisimuRosDriver::isAsciiSensorData(unsigned char * imu_data_buf, unsigned int data_size)
@@ -202,7 +202,7 @@ bool RtUsb9axisimuRosDriver::isValidAsciiSensorData(std::vector<std::string> str
   return true;
 }
 
-bool RtUsb9axisimuRosDriver::readAsciiData(void)
+RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readAsciiData(void)
 {
   static std::vector<std::string> imu_data_vector_buf;
 
@@ -216,7 +216,15 @@ bool RtUsb9axisimuRosDriver::readAsciiData(void)
   int data_size_of_buf = serial_port_->readFromDevice(imu_data_buf, sizeof(imu_data_buf));
 
   if (data_size_of_buf <= 0) {
-    return false;  // Raise communication error
+    return RtUsb9axisimuRosDriver::ReadStatus::FAILURE;  // Raise communication error
+  }
+
+  if(data_size_of_buf < 0){  // read() returns error code.
+    if(errno == EAGAIN || errno == EWOULDBLOCK){  // Waiting for data.
+      return RtUsb9axisimuRosDriver::ReadStatus::NEED_TO_CONTINUE;
+    }else{
+      return RtUsb9axisimuRosDriver::ReadStatus::FAILURE;
+    }
   }
 
   for (int char_count = 0; char_count < data_size_of_buf; char_count++) {
@@ -256,7 +264,7 @@ bool RtUsb9axisimuRosDriver::readAsciiData(void)
     }
   }
 
-  return true;
+  return RtUsb9axisimuRosDriver::ReadStatus::SUCCESS;
 }
 
 RtUsb9axisimuRosDriver::RtUsb9axisimuRosDriver(std::string port = "")
@@ -432,7 +440,7 @@ std::unique_ptr<std_msgs::msg::Float64> RtUsb9axisimuRosDriver::getImuTemperatur
 
 // Method to receive IMU data, convert those units to SI, and publish to ROS
 // topic
-bool RtUsb9axisimuRosDriver::readSensorData()
+RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readSensorData()
 {
   if (data_format_ == DataFormat::BINARY) {
     return readBinaryData();
@@ -440,5 +448,5 @@ bool RtUsb9axisimuRosDriver::readSensorData()
     return readAsciiData();
   }
 
-  return false;
+  return RtUsb9axisimuRosDriver::ReadStatus::FAILURE;
 }

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -116,8 +116,7 @@ RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readBinaryData(void)
   unsigned char read_data_buf[consts.READ_BUFFER_SIZE];
 
   has_refreshed_imu_data_ = false;
-  int read_data_size = serial_port_->readFromDevice(read_data_buf,
-    consts.IMU_BIN_DATA_SIZE - imu_binary_data_buffer.size());
+  int read_data_size = serial_port_->readFromDevice(read_data_buf, sizeof(read_data_buf));
 
   if(read_data_size == 0){  // The device was unplugged.
     return RtUsb9axisimuRosDriver::ReadStatus::FAILURE;
@@ -131,8 +130,16 @@ RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readBinaryData(void)
     }
   }
 
+  int buf_start_idx = 0;
+  for(int i = 0; i < read_data_size-3; i++) {
+    if(read_data_buf[i] == 0xff && read_data_buf[i+1] == 0xff &&
+       read_data_buf[i+2] == 'R' && read_data_buf[i+3] == 'T') {
+      buf_start_idx = i;
+    }
+  }
+
   for(int i = 0; i < read_data_size; i++){
-    imu_binary_data_buffer.push_back(read_data_buf[i]);
+    imu_binary_data_buffer.push_back(read_data_buf[i+buf_start_idx]);
   }
 
   if (imu_binary_data_buffer.size() < consts.IMU_BIN_DATA_SIZE){
@@ -227,7 +234,14 @@ RtUsb9axisimuRosDriver::ReadStatus RtUsb9axisimuRosDriver::readAsciiData(void)
     }
   }
 
-  for (int char_count = 0; char_count < data_size_of_buf; char_count++) {
+  int buf_start_idx = 0;
+  for (int i = 0; i < data_size_of_buf-consts.IMU_ASCII_DATA_SIZE; i++) {
+    if(imu_data_buf[i] == '\n') {
+      buf_start_idx = i;
+    }
+  }
+
+  for (int char_count = buf_start_idx; char_count < data_size_of_buf; char_count++) {
     if (imu_data_buf[char_count] == ',' || imu_data_buf[char_count] == '\n') {
       imu_data_vector_buf.push_back(imu_data_oneline_buf);
       // If the imu_data_oneline_buf is empty string (such as receiving

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -521,3 +521,101 @@ INSTANTIATE_TEST_SUITE_P(
     ReadAsciiTestParam(10)
   )
 );
+
+TEST(TestDriver, get_latest_data_Binary) {
+  // Expect to check the latest data is correctly read when binary sequential data is read
+  auto mock = create_serial_port_mock();
+  const int MAX_CASE_NUM = 3;
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  When(Method(mock, readFromDevice)).AlwaysDo([&](
+    unsigned char* buf, unsigned int buf_size) {
+    rt_usb_9axisimu::Consts consts;
+    buf_size = 0;
+    for(int i = 0; i < MAX_CASE_NUM; i++) {
+      unsigned char oneset_data[consts.IMU_BIN_DATA_SIZE];
+      ReadBinaryTestParam data(i);
+      auto oneset_size = create_dummy_bin_imu_data(oneset_data, false, data.gyro, data.acc, data.mag, data.temp);
+      for(unsigned int j = 0; j < oneset_size; j++) {
+        buf[j+buf_size] = oneset_data[j];
+      }
+      buf_size += oneset_size;
+    }
+    return buf_size;
+  });
+
+  driver.checkDataFormat();
+  driver.readSensorData();
+
+  rclcpp::Time timestamp;
+  auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
+  auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
+  auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
+
+  ReadBinaryTestParam data(MAX_CASE_NUM-1);
+  const double abs_error_acc = 1e-3;
+  const double abs_error_gyro = 1e-3;
+  const double abs_error_mag = 1e-5;
+  const double abs_error_temp = 1e-3;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error_gyro);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error_mag);
+  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error_temp);
+}
+
+TEST(TestDriver, get_latest_data_ASCII) {
+  // Expect to check the latest data is correctly read when ascii sequential data is read
+  auto mock = create_serial_port_mock();
+  const int MAX_CASE_NUM = 3;
+
+  RtUsb9axisimuRosDriver driver(
+    std::unique_ptr<SerialPort>(&mock.get()));
+
+  When(Method(mock, readFromDevice)).AlwaysDo([&](
+    unsigned char* buf, unsigned int buf_size) {
+    rt_usb_9axisimu::Consts consts;
+    buf_size = 0;
+    for(int i = 0; i < MAX_CASE_NUM; i++) {
+      unsigned char oneset_data[consts.IMU_ASCII_DATA_SIZE];
+      ReadAsciiTestParam data(i);
+      auto oneset_size = create_dummy_ascii_imu_data(oneset_data, false, data.gyro, data.acc, data.mag, data.temp);
+      for(unsigned int j = 0; j < oneset_size; j++) {
+        buf[j+buf_size] = oneset_data[j];
+      }
+      buf_size += oneset_size;
+    }
+    return buf_size;
+  });
+
+  driver.checkDataFormat();
+  driver.readSensorData();
+
+  rclcpp::Time timestamp;
+  auto imu_data_raw = driver.getImuRawDataUniquePtr(timestamp);
+  auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
+  auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
+
+  ReadBinaryTestParam data(MAX_CASE_NUM-1);
+  const double abs_error_acc = 1e-3;
+  const double abs_error_gyro = 1e-3;
+  const double abs_error_mag = 1e-5;
+  const double abs_error_temp = 1e-3;
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.x, data.ans_acc[0], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.y, data.ans_acc[1], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->linear_acceleration.z, data.ans_acc[2], abs_error_acc);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.x, data.ans_gyro[0], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.y, data.ans_gyro[1], abs_error_gyro);
+  EXPECT_NEAR(imu_data_raw->angular_velocity.z, data.ans_gyro[2], abs_error_gyro);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.x, data.ans_mag[0], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.y, data.ans_mag[1], abs_error_mag);
+  EXPECT_NEAR(imu_data_mag->magnetic_field.z, data.ans_mag[2], abs_error_mag);
+  EXPECT_NEAR(imu_data_temperature->data, data.ans_temp, abs_error_temp);
+}

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -603,7 +603,7 @@ TEST(TestDriver, get_latest_data_ASCII) {
   auto imu_data_mag = driver.getImuMagUniquePtr(timestamp);
   auto imu_data_temperature = driver.getImuTemperatureUniquePtr();
 
-  ReadBinaryTestParam data(MAX_CASE_NUM-1);
+  ReadAsciiTestParam data(MAX_CASE_NUM-1);
   const double abs_error_acc = 1e-3;
   const double abs_error_gyro = 1e-3;
   const double abs_error_mag = 1e-5;

--- a/test/test_driver.cpp
+++ b/test/test_driver.cpp
@@ -535,7 +535,7 @@ TEST(TestDriver, get_latest_data_Binary) {
     rt_usb_9axisimu::Consts consts;
     buf_size = 0;
     for(int i = 0; i < MAX_CASE_NUM; i++) {
-      unsigned char oneset_data[consts.IMU_BIN_DATA_SIZE];
+      unsigned char oneset_data[consts.READ_BUFFER_SIZE];
       ReadBinaryTestParam data(i);
       auto oneset_size = create_dummy_bin_imu_data(oneset_data, false, data.gyro, data.acc, data.mag, data.temp);
       for(unsigned int j = 0; j < oneset_size; j++) {
@@ -584,7 +584,7 @@ TEST(TestDriver, get_latest_data_ASCII) {
     rt_usb_9axisimu::Consts consts;
     buf_size = 0;
     for(int i = 0; i < MAX_CASE_NUM; i++) {
-      unsigned char oneset_data[consts.IMU_ASCII_DATA_SIZE];
+      unsigned char oneset_data[consts.READ_BUFFER_SIZE];
       ReadAsciiTestParam data(i);
       auto oneset_size = create_dummy_ascii_imu_data(oneset_data, false, data.gyro, data.acc, data.mag, data.temp);
       for(unsigned int j = 0; j < oneset_size; j++) {


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
複数セットのデータを読み込んだ時に最新のデータが取得されることを確認するテストを追加します。
また、https://github.com/rt-net/rt_usb_9axisimu_driver/pull/50 を参考にして繰り返しread関数を実行するように変更しています。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
https://github.com/rt-net/rt_usb_9axisimu_driver/issues/49 に対応します。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
`colcon test`ですべてのテストが通ることを確認しました。
実機においてBinaryモードとASCIIモードのどちらでも動作を確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->
- rt_usb_9axisimu_driver_component.cppも修正していますが、システムテストは行っていないため、ノードとして正常に動作するかどうかの確認は、現状実機での動作確認だけです。
- rt_usb_9axisimu_driver.hppにおいて、ReadStatusを使用するためにRtUsb9axisimuRosDriverクラスのPrivateとPublicの順番を逆にしました（その分差分が大きくなっています）。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
