### PR TITLE
センサからデータが取得できるかのチェックにタイムアウト機能を追加

### DIFF
--- a/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
+++ b/include/rt_usb_9axisimu_driver/rt_usb_9axisimu_driver.hpp
@@ -65,6 +65,7 @@ public:
   bool startCommunication();
   void stopCommunication(void);
   void checkDataFormat(const double timeout = 5.0);
+  bool checkReadData(const double timeout = 5.0);
   bool hasAsciiDataFormat(void);
   bool hasBinaryDataFormat(void);
   bool hasRefreshedImuData(void);

--- a/src/rt_usb_9axisimu_driver.cpp
+++ b/src/rt_usb_9axisimu_driver.cpp
@@ -366,6 +366,20 @@ void RtUsb9axisimuRosDriver::checkDataFormat(const double timeout)
   }
 }
 
+bool RtUsb9axisimuRosDriver::checkReadData(const double timeout)
+{
+  const auto start_time = std::chrono::system_clock::now();
+  double time_elapsed = 0.0;
+  while (time_elapsed < timeout) {
+    const auto end_time = std::chrono::system_clock::now();
+    time_elapsed = (double)std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time).count();
+    if (readSensorData() == RtUsb9axisimuRosDriver::ReadStatus::SUCCESS) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool RtUsb9axisimuRosDriver::hasAsciiDataFormat(void)
 {
   return data_format_ == DataFormat::ASCII;

--- a/src/rt_usb_9axisimu_driver_component.cpp
+++ b/src/rt_usb_9axisimu_driver_component.cpp
@@ -126,8 +126,8 @@ CallbackReturn Driver::on_activate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(this->get_logger(), "on_activate() is called.");
 
-  if (driver_->readSensorData() == RtUsb9axisimuRosDriver::ReadStatus::FAILURE) {
-    RCLCPP_ERROR(this->get_logger(), "readSensorData() returns FAILURE, please check your devices.");
+  if (!driver_->checkReadData()) {
+    RCLCPP_ERROR(this->get_logger(), "checkReadData() returns false, please check your devices.");
     return CallbackReturn::ERROR;
   }
   imu_data_raw_pub_->on_activate();


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
lifecycleのactivate時のセンサからデータが取得できるかのチェックは、元々はreadSensorData()の実行が成功するかどうかチェックしていましたが現在の方法だと正しくIMUセンサが接続されていてもタイミングによって失敗することがあるため、タイムアウト機能を追加して設定した時間内でセンサデータが取得できるかチェックするように変更します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記コマンドを実行してIMUノードのlifecycleがactiveへ遷移できることを確認しました。

```sh
# ターミナル1
ros2 run rt_usb_9axisimu_driver rt_usb_9axisimu_driver

# ターミナル2
ros2 lifecycle set rt_usb_9axisimu_driver configure
ros2 lifecycle set rt_usb_9axisimu_driver activate
```

また、`ros2 lifecycle set rt_usb_9axisimu_driver configure`実行後にPCから9軸IMUセンサの接続を外して`ros2 lifecycle set rt_usb_9axisimu_driver activate`を実行すると、5秒後にタイムアウトしてactivateに失敗することも確認できました。

# Any other comments?
<!-- その他コメントはありますか？ -->
本PR作成の背景として、launchファイルからlifecycleを遷移させる際、configure後すぐにactivateを行うとreadSensorData()に失敗する場合があることを確認したため、センサからデータが取得できるかのチェック時にタイムアウト機能を追加することにしました。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
